### PR TITLE
Trigger rate plot implemented as additional GUI display option

### DIFF
--- a/include/AAAcquisitionManager.hh
+++ b/include/AAAcquisitionManager.hh
@@ -174,6 +174,7 @@ private:
 
   // vector<TGraph *> Rate_P;
   vector< list<unsigned int> * > Rate_C;
+  unsigned int RateAccum;
   vector<double> Rate_Lead;
   vector<Bool_t> RateExists;
   

--- a/include/AAAcquisitionManager.hh
+++ b/include/AAAcquisitionManager.hh
@@ -161,6 +161,7 @@ private:
   vector<ULong64_t> CorrectedTimeStamp;
 #ifndef __CINT__
   vector<uint32_t> PrevTimeStamp, TimeStampRollovers;
+  vector<ULong64_t> PrevCorTimeStamp;
   uint32_t RawTimeStamp;
 #endif
 

--- a/include/AAAcquisitionManager.hh
+++ b/include/AAAcquisitionManager.hh
@@ -166,6 +166,9 @@ private:
   
   vector<TH1F *> Spectrum_H;
   vector<Bool_t> SpectrumExists;
+
+  vector<TH1F *> Rate_H;
+  vector<Bool_t> RateExists;
   
   vector<TH2F *> PSDHistogram_H;
   vector<Bool_t> PSDHistogramExists;

--- a/include/AAAcquisitionManager.hh
+++ b/include/AAAcquisitionManager.hh
@@ -87,7 +87,10 @@ public:
 
   TH1F *GetSpectrum(Int_t C) {return Spectrum_H[C];}
   TGraph *GetCalibrationCurve(Int_t C) {return CalibrationCurves[C];}
-  
+
+  void SetupRateVector();
+  TGraph *GetRatePlot(Int_t C) {return Rate_P[C];}
+
   TH2F *GetPSDHistogram(Int_t C) {return PSDHistogram_H[C];}
   
   TString GetADAQFileComment() {return TheReadoutManager->GetFileComment();}
@@ -167,7 +170,8 @@ private:
   vector<TH1F *> Spectrum_H;
   vector<Bool_t> SpectrumExists;
 
-  vector<TH1F *> Rate_H;
+  vector<TGraph *> Rate_P;
+  vector< vector<unsigned int> > Rate_C;
   vector<Bool_t> RateExists;
   
   vector<TH2F *> PSDHistogram_H;

--- a/include/AAAcquisitionManager.hh
+++ b/include/AAAcquisitionManager.hh
@@ -30,6 +30,7 @@
 
 // C++
 #include <vector>
+#include <list>
 #include <string>
 using namespace std;
 
@@ -89,7 +90,7 @@ public:
   TGraph *GetCalibrationCurve(Int_t C) {return CalibrationCurves[C];}
 
   void SetupRateVector();
-  TGraph *GetRatePlot(Int_t C) {return Rate_P[C];}
+  list<unsigned int> * GetRateList(Int_t C) {return Rate_C[C];}
 
   TH2F *GetPSDHistogram(Int_t C) {return PSDHistogram_H[C];}
   
@@ -170,8 +171,9 @@ private:
   vector<TH1F *> Spectrum_H;
   vector<Bool_t> SpectrumExists;
 
-  vector<TGraph *> Rate_P;
-  vector< vector<unsigned int> > Rate_C;
+  // vector<TGraph *> Rate_P;
+  vector< list<unsigned int> * > Rate_C;
+  vector<double> Rate_Lead;
   vector<Bool_t> RateExists;
   
   vector<TH2F *> PSDHistogram_H;

--- a/include/AAGraphics.hh
+++ b/include/AAGraphics.hh
@@ -61,7 +61,7 @@ public:
   void PlotSpectrum(TH1F *);
 
   void SetupRateGraphics();
-  void PlotRate(TGraph *);
+  void PlotRate(Double_t tss);
   
   void SetupPSDHistogramGraphics();
   void PlotPSDHistogram(TH2F *);
@@ -92,6 +92,8 @@ private:
   AASettings *TheSettings;
 
   vector<Int_t> Time;
+
+  TGraph * RateGraph;
 
   string Title, XTitle, YTitle;
   Double_t XSize, YSize, XOffset, YOffset;

--- a/include/AAGraphics.hh
+++ b/include/AAGraphics.hh
@@ -61,7 +61,7 @@ public:
   void PlotSpectrum(TH1F *);
 
   void SetupRateGraphics();
-  void PlotRate(TH1F *);
+  void PlotRate(TGraph *);
   
   void SetupPSDHistogramGraphics();
   void PlotPSDHistogram(TH2F *);

--- a/include/AAGraphics.hh
+++ b/include/AAGraphics.hh
@@ -59,6 +59,9 @@ public:
 
   void SetupSpectrumGraphics();
   void PlotSpectrum(TH1F *);
+
+  void SetupRateGraphics();
+  void PlotRate(TH1F *);
   
   void SetupPSDHistogramGraphics();
   void PlotPSDHistogram(TH2F *);

--- a/include/AAGraphics.hh
+++ b/include/AAGraphics.hh
@@ -93,7 +93,8 @@ private:
 
   vector<Int_t> Time;
 
-  TGraph * RateGraph;
+  TGraph *RateGraph;
+  TH1F *RateGraphAxes_H;
 
   string Title, XTitle, YTitle;
   Double_t XSize, YSize, XOffset, YOffset;

--- a/include/AAGraphics.hh
+++ b/include/AAGraphics.hh
@@ -87,7 +87,7 @@ private:
 
   vector<Int_t> ChColor;
 
-  Int_t MaxWaveformLength, WaveformWidth, SpectrumWidth;
+  Int_t MaxWaveformLength, WaveformWidth, SpectrumWidth, MaxRateSize;
 
   AASettings *TheSettings;
 
@@ -95,6 +95,8 @@ private:
 
   TGraph *RateGraph;
   TH1F *RateGraphAxes_H;
+  vector<Double_t> timeR;
+  vector<Double_t> rateR;
 
   string Title, XTitle, YTitle;
   Double_t XSize, YSize, XOffset, YOffset;

--- a/include/AAGraphics.hh
+++ b/include/AAGraphics.hh
@@ -94,7 +94,6 @@ private:
   vector<Int_t> Time;
 
   TGraph *RateGraph;
-  TH1F *RateGraphAxes_H;
   vector<Double_t> timeR;
   vector<Double_t> rateR;
 

--- a/include/AAGraphics.hh
+++ b/include/AAGraphics.hh
@@ -94,6 +94,7 @@ private:
   vector<Int_t> Time;
 
   TGraph *RateGraph;
+  TH1F *RateGraphAxes_H;
   vector<Double_t> timeR;
   vector<Double_t> rateR;
 

--- a/include/AAInterface.hh
+++ b/include/AAInterface.hh
@@ -379,8 +379,10 @@ private:
 
   ADAQNumberEntryWithLabel *SpectrumRefreshRate_NEL;
 
+  ADAQComboBoxWithLabel *RateChannel_CBL;
   ADAQNumberEntryWithLabel *RatePlotDisp_NEL;
   ADAQNumberEntryWithLabel *RatePlotPeriod_NEL;
+  ADAQNumberEntryWithLabel *RateTSResolution_NEL;
 
   TGRadioButton *DisplayContinuous_RB, *DisplayUpdateable_RB, *DisplayNonUpdateable_RB;
 

--- a/include/AAInterface.hh
+++ b/include/AAInterface.hh
@@ -382,7 +382,6 @@ private:
   ADAQComboBoxWithLabel *RateChannel_CBL;
   ADAQNumberEntryWithLabel *RatePlotDisp_NEL;
   ADAQNumberEntryWithLabel *RatePlotPeriod_NEL;
-  ADAQNumberEntryWithLabel *RateTSResolution_NEL;
 
   TGRadioButton *DisplayContinuous_RB, *DisplayUpdateable_RB, *DisplayNonUpdateable_RB;
 

--- a/include/AAInterface.hh
+++ b/include/AAInterface.hh
@@ -379,6 +379,9 @@ private:
 
   ADAQNumberEntryWithLabel *SpectrumRefreshRate_NEL;
 
+  ADAQNumberEntryWithLabel *RatePlotDisp_NEL;
+  ADAQNumberEntryWithLabel *RatePlotPeriod_NEL;
+
   TGRadioButton *DisplayContinuous_RB, *DisplayUpdateable_RB, *DisplayNonUpdateable_RB;
 
 

--- a/include/AAInterface.hh
+++ b/include/AAInterface.hh
@@ -277,7 +277,7 @@ private:
   
   // Data acquisition subtab
   
-  TGRadioButton *AQWaveform_RB, *AQSpectrum_RB, *AQPSDHistogram_RB;
+  TGRadioButton *AQWaveform_RB, *AQSpectrum_RB, *AQPSDHistogram_RB, *AQRate_RB;
 
   ADAQComboBoxWithLabel *DGTriggerType_CBL;
   ADAQComboBoxWithLabel *DGTriggerEdge_CBL;

--- a/include/AASettings.hh
+++ b/include/AASettings.hh
@@ -205,6 +205,9 @@ public:
   ////////////////////////////////////
   // Rate plot widget settings
   Int_t RateChannel;
+  Int_t RateNumPeriods;
+  Double_t RateIntegrationPeriod;
+  Double_t RateDisplayPeriod;
 
   //////////////////////////////
   // Pulse discrimination limits

--- a/include/AASettings.hh
+++ b/include/AASettings.hh
@@ -155,6 +155,7 @@ public:
   Bool_t WaveformMode;
   Bool_t SpectrumMode;
   Bool_t PSDMode;
+  Bool_t RateMode;
   Bool_t PSDListAnalysis, PSDWaveformAnalysis;
   
   // Trigger
@@ -201,6 +202,9 @@ public:
   Bool_t SpectrumCalibrationUseSlider;
   string SpectrumCalibrationUnit;
 
+  ////////////////////////////////////
+  // Rate plot widget settings
+  Int_t RateChannel;
 
   //////////////////////////////
   // Pulse discrimination limits

--- a/include/AASettings.hh
+++ b/include/AASettings.hh
@@ -208,6 +208,7 @@ public:
   Int_t RateNumPeriods;
   Double_t RateIntegrationPeriod;
   Double_t RateDisplayPeriod;
+  Double_t RateTSResolution;
 
   //////////////////////////////
   // Pulse discrimination limits

--- a/include/AASettings.hh
+++ b/include/AASettings.hh
@@ -208,7 +208,6 @@ public:
   Int_t RateNumPeriods;
   Double_t RateIntegrationPeriod;
   Double_t RateDisplayPeriod;
-  Double_t RateTSResolution;
 
   //////////////////////////////
   // Pulse discrimination limits

--- a/include/AATypes.hh
+++ b/include/AATypes.hh
@@ -355,7 +355,10 @@ enum{
 
   DisplayContinuous_RB_ID,
   DisplayUpdateable_RB_ID,
-  DisplayNonUpdateable_RB_ID
+  DisplayNonUpdateable_RB_ID,
+
+  RateChannel_CBL_ID,
+  RateDrawOptions_CBL_ID
 };
 
 struct CalibrationDataStruct{

--- a/include/AATypes.hh
+++ b/include/AATypes.hh
@@ -243,6 +243,7 @@ enum{
   AQWaveform_RB_ID,
   AQSpectrum_RB_ID,
   AQPSDHistogram_RB_ID,
+  AQRate_RB_ID,
   
   DGTriggerType_CBL_ID,
   DGTriggerEdge_CBL_ID,

--- a/src/AAAcquisitionManager.cc
+++ b/src/AAAcquisitionManager.cc
@@ -108,6 +108,7 @@ void AAAcquisitionManager::Initialize()
     
     CorrectedTimeStamp.push_back(0);
     PrevTimeStamp.push_back(0);
+    PrevCorTimeStamp.push_back(0);
     TimeStampRollovers.push_back(0);
   }
 }
@@ -344,6 +345,7 @@ void AAAcquisitionManager::PrepareAcquisition()
     // Reset time stamp variables 
     TimeStampRollovers[ch] = 0;
     PrevTimeStamp[ch] = 0;
+    PrevCorTimeStamp[ch] = 0;
     CorrectedTimeStamp[ch] = 0;
   }
 
@@ -757,6 +759,7 @@ void AAAcquisitionManager::StartAcquisition()
 	  TimeStampRollovers[ch]++;
 	
 	// Compute the corrected time stamp; store as 64-bit integer
+        PrevCorTimeStamp[ch] = CorrectedTimeStamp[ch];
 	CorrectedTimeStamp[ch] = (ULong64_t)(RawTimeStamp + TimeStampRollovers[ch] * pow(2,31));
 
 	// Set the previous time stamp
@@ -883,7 +886,7 @@ void AAAcquisitionManager::StartAcquisition()
 
     else if(TheSettings->RateMode){
       Double_t tss = ((Double_t)CorrectedTimeStamp[ch])*TheSettings->RateTSResolution*1e-9;
-
+        
       // std::cout<<tss<<" "<<Rate_C[ch]->size()<<" "<<Rate_Lead[ch]<<" "<<TheSettings->RateNumPeriods<<"\n";
 
       // First event initialization

--- a/src/AAAcquisitionManager.cc
+++ b/src/AAAcquisitionManager.cc
@@ -762,8 +762,8 @@ void AAAcquisitionManager::StartAcquisition()
         }
 	
 	// Compute the corrected time stamp; store as 64-bit integer
-        PrevCorTimeStamp[ch] = CorrectedTimeStamp[ch];
-	CorrectedTimeStamp[ch] = (ULong64_t)(RawTimeStamp + TimeStampRollovers[ch] * pow(2,32));
+  PrevCorTimeStamp[ch] = CorrectedTimeStamp[ch];
+	CorrectedTimeStamp[ch] = (ULong64_t)(RawTimeStamp + TimeStampRollovers[ch] * ((ULong64_t)1<<DGManager->GetTimeStampSize()));// pow(2,32));
 
 	// Set the previous time stamp
 	PrevTimeStamp[ch] = RawTimeStamp;
@@ -888,7 +888,7 @@ void AAAcquisitionManager::StartAcquisition()
 	  }
 
     else if(TheSettings->RateMode){
-      Double_t tss = ((Double_t)CorrectedTimeStamp[ch])*TheSettings->RateTSResolution*1e-9;
+      Double_t tss = ((Double_t)CorrectedTimeStamp[ch])*DGManager->GetTimeStampUnit()*1e-9;
       
       if (PrevCorTimeStamp[ch]>CorrectedTimeStamp[ch]) cout<<"BACK IN TIME "<<PrevCorTimeStamp[ch]<<" "<<CorrectedTimeStamp[ch]<<"\n";
       // std::cout<<tss<<" "<<Rate_C[ch]->size()<<" "<<Rate_Lead[ch]<<" "<<TheSettings->RateNumPeriods<<"\n";
@@ -905,7 +905,9 @@ void AAAcquisitionManager::StartAcquisition()
         Rate_C[ch]->resize(tvi+1,0);
       }
 
-      // Timestamps are not ordered, so may need to iterate to correct bin
+      // Timestamps are not ordered, so may need to iterate to correct bin (OK,
+      // turns out they are, but this shouldn't cause a slowdown and maintains
+      // generality for the case that they may not be)
       UInt_t diff = (Rate_C[ch]->size()-1) - tvi;
       UInt_t dcnt = 0;
       for (std::list<unsigned int>::reverse_iterator it=Rate_C[ch]->rbegin(); it != Rate_C[ch]->rend(); ++it, dcnt++)

--- a/src/AAAcquisitionManager.cc
+++ b/src/AAAcquisitionManager.cc
@@ -394,6 +394,7 @@ void AAAcquisitionManager::PrepareAcquisition()
 
 void AAAcquisitionManager::StartAcquisition()
 {
+  unsigned int hys = 0;
   ADAQDigitizer *DGManager = AAVMEManager::GetInstance()->GetDGManager();
   
   AAGraphics *TheGraphicsManager = AAGraphics::GetInstance();
@@ -897,9 +898,14 @@ void AAAcquisitionManager::StartAcquisition()
         Rate_C[ch]->resize(tvi+1,0);
       }
 
-      // Last element of list now corresponds to current event if it didn't
-      // before
-      Rate_C[ch]->back()++;
+      // Timestamps are not ordered, so may need to iterate to correct bin
+      UInt_t diff = (Rate_C[ch]->size()-1) - tvi;
+      UInt_t dcnt = 0;
+      for (std::list<unsigned int>::reverse_iterator it=Rate_C[ch]->rbegin(); it != Rate_C[ch]->rend(); ++it, dcnt++)
+        if (dcnt == diff){
+          (*it)++;
+          break;
+        }
     
       // Trim front of container if beyond number of requested periods and
       // corresponding increment the list start time

--- a/src/AAAcquisitionManager.cc
+++ b/src/AAAcquisitionManager.cc
@@ -883,6 +883,8 @@ void AAAcquisitionManager::StartAcquisition()
     else if(TheSettings->RateMode){
       Double_t tss = ((Double_t)CorrectedTimeStamp[ch])*TheSettings->RateTSResolution*1e-9;
 
+      // std::cout<<tss<<" "<<Rate_C[ch]->size()<<" "<<Rate_Lead[ch]<<" "<<TheSettings->RateNumPeriods<<"\n";
+
       // First event initialization
       if (Rate_Lead[ch] == std::numeric_limits<double>::max())
         Rate_Lead[ch] = tss;
@@ -891,7 +893,7 @@ void AAAcquisitionManager::StartAcquisition()
       UInt_t tvi = (tss-Rate_Lead[ch])/TheSettings->RateIntegrationPeriod;
 
       // Increase size of storage list if needed
-      if(tvi>=Rate_C[ch]->size()){
+      if(tvi>=(double)Rate_C[ch]->size()){
         Rate_C[ch]->resize(tvi+1,0);
       }
 
@@ -905,6 +907,8 @@ void AAAcquisitionManager::StartAcquisition()
         Rate_C[ch]->pop_front();
         Rate_Lead[ch]+=TheSettings->RateIntegrationPeriod;
       }
+
+      // std::cout<<tss<<" "<<Rate_C[ch]->size()<<" "<<Rate_Lead[ch]<<" "<<TheSettings->RateNumPeriods<<"\n\n";
     }
 	}
 	
@@ -1435,6 +1439,7 @@ void AAAcquisitionManager::SetupRateVector()
   for(Int_t ch=0; ch<AAVMEManager::GetInstance()->GetDGManager()->GetNumChannels(); ch++){
     // Rate_C[ch]->reserve(TheSettings->RateNumPeriods);
     Rate_Lead[ch] = std::numeric_limits<double>::max();
+    Rate_C[ch]->clear();
   }
 }
 

--- a/src/AAAcquisitionManager.cc
+++ b/src/AAAcquisitionManager.cc
@@ -756,11 +756,14 @@ void AAAcquisitionManager::StartAcquisition()
 	
 	// Test the time stamp for a rollover and increment if found
 	if(RawTimeStamp < PrevTimeStamp[ch])
+	{
+          // std::cout<<"Rolling "<<CorrectedTimeStamp[ch]<<" "<<RawTimeStamp<<" "<<PrevTimeStamp[ch]<<"\n";
 	  TimeStampRollovers[ch]++;
+        }
 	
 	// Compute the corrected time stamp; store as 64-bit integer
         PrevCorTimeStamp[ch] = CorrectedTimeStamp[ch];
-	CorrectedTimeStamp[ch] = (ULong64_t)(RawTimeStamp + TimeStampRollovers[ch] * pow(2,31));
+	CorrectedTimeStamp[ch] = (ULong64_t)(RawTimeStamp + TimeStampRollovers[ch] * pow(2,32));
 
 	// Set the previous time stamp
 	PrevTimeStamp[ch] = RawTimeStamp;
@@ -886,7 +889,8 @@ void AAAcquisitionManager::StartAcquisition()
 
     else if(TheSettings->RateMode){
       Double_t tss = ((Double_t)CorrectedTimeStamp[ch])*TheSettings->RateTSResolution*1e-9;
-        
+      
+      if (PrevCorTimeStamp[ch]>CorrectedTimeStamp[ch]) cout<<"BACK IN TIME "<<PrevCorTimeStamp[ch]<<" "<<CorrectedTimeStamp[ch]<<"\n";
       // std::cout<<tss<<" "<<Rate_C[ch]->size()<<" "<<Rate_Lead[ch]<<" "<<TheSettings->RateNumPeriods<<"\n";
 
       // First event initialization

--- a/src/AAAcquisitionManager.cc
+++ b/src/AAAcquisitionManager.cc
@@ -1405,6 +1405,8 @@ void AAAcquisitionManager::CloseADAQFile()
 
 void AAAcquisitionManager::SetupRateVector()
 {
+  TheSettings->RateNumPeriods = (int)(TheSettings->RateDisplayPeriod/TheSettings->RateIntegrationPeriod);
+
   for(Int_t ch=0; ch<AAVMEManager::GetInstance()->GetDGManager()->GetNumChannels(); ch++){
     Rate_C[ch].reserve(TheSettings->RateNumPeriods);
   }

--- a/src/AAAcquisitionManager.cc
+++ b/src/AAAcquisitionManager.cc
@@ -877,10 +877,6 @@ void AAAcquisitionManager::StartAcquisition()
 	      PSDHistogram_H[ch]->Fill(PSDTotal, PSDParameter);
 	    }
 	  }
-
-    else if(TheSettings->RateMode){
-      
-    }
 	}
 	
 	///////////////////////////////////////
@@ -991,10 +987,10 @@ void AAAcquisitionManager::StartAcquisition()
           TheGraphicsManager->PlotSpectrum(Spectrum_H[TheSettings->SpectrumChannel]);
       }
 
-      else if(TheSettings->RateMode){
-        if(EventCounter % Rate == 0)
-          TheGraphicsManager->PlotRate(Rate_P[TheSettings->RateChannel]);
-      }
+//      else if(TheSettings->RateMode){
+//        if(EventCounter % Rate == 0)
+//          TheGraphicsManager->PlotRate(Rate_P[TheSettings->RateChannel]);
+//      }
       
       else if(TheSettings->PSDMode){
         if(EventCounter % Rate == 0){

--- a/src/AAAcquisitionManager.cc
+++ b/src/AAAcquisitionManager.cc
@@ -96,6 +96,9 @@ void AAAcquisitionManager::Initialize()
     Spectrum_H.push_back(new TH1F);
     SpectrumExists.push_back(true);
 
+    Rate_H.push_back(new TH1F);
+    RateExists.push_back(true);
+
     PSDHistogram_H.push_back(new TH2F);
     PSDHistogramExists.push_back(true);
     
@@ -327,7 +330,9 @@ void AAAcquisitionManager::PrepareAcquisition()
     AAGraphics::GetInstance()->SetupSpectrumGraphics();
   else if(TheSettings->PSDMode)
     AAGraphics::GetInstance()->SetupPSDHistogramGraphics();
-  
+  else if(TheSettings->RateMode)
+    AAGraphics::GetInstance()->SetupRateGraphics();
+
   for(Int_t ch=0; ch<NumDGChannels; ch++){
     NumPSDEvents[ch] = 0;
     
@@ -869,6 +874,9 @@ void AAAcquisitionManager::StartAcquisition()
 	      PSDHistogram_H[ch]->Fill(PSDTotal, PSDParameter);
 	    }
 	  }
+
+    else if(TheSettings->RateMode){
+    }
 	}
 	
 	///////////////////////////////////////
@@ -958,7 +966,7 @@ void AAAcquisitionManager::StartAcquisition()
 
       // Zero the number of of PSD events after each channel readout.
       if(UsePSDFirmware)
-	NumPSDEvents[ch] = 0;
+        NumPSDEvents[ch] = 0;
       
     }// End of the data readout loop over channels
 
@@ -975,14 +983,19 @@ void AAAcquisitionManager::StartAcquisition()
       Int_t Rate = TheSettings->SpectrumRefreshRate;
       
       if(TheSettings->SpectrumMode){
-	if(EventCounter % Rate == 0)
-	  TheGraphicsManager->PlotSpectrum(Spectrum_H[TheSettings->SpectrumChannel]);
+        if(EventCounter % Rate == 0)
+          TheGraphicsManager->PlotSpectrum(Spectrum_H[TheSettings->SpectrumChannel]);
+      }
+
+      else if(TheSettings->RateMode){
+        if(EventCounter % Rate == 0)
+          TheGraphicsManager->PlotRate(Rate_H[TheSettings->RateChannel]);
       }
       
       else if(TheSettings->PSDMode){
-	if(EventCounter % Rate == 0){
-	  TheGraphicsManager->PlotPSDHistogram(PSDHistogram_H[TheSettings->PSDChannel]);
-	}
+        if(EventCounter % Rate == 0){
+          TheGraphicsManager->PlotPSDHistogram(PSDHistogram_H[TheSettings->PSDChannel]);
+        }
       }
     }
   } // End of the acquisition loop
@@ -1131,10 +1144,10 @@ void AAAcquisitionManager::SaveObjectData(string ObjectType,
       }
       
       else if(ObjectType == "Spectrum")
-	Spectrum_H[Channel]->Write("Spectrum");
+        Spectrum_H[Channel]->Write("Spectrum");
       
       else if(ObjectType == "PSDHistogram")
-	PSDHistogram_H[Channel]->Write("PSDHistogram");
+        PSDHistogram_H[Channel]->Write("PSDHistogram");
       
       ObjectOutput->Close();
     }

--- a/src/AADisplaySlots.cc
+++ b/src/AADisplaySlots.cc
@@ -52,7 +52,7 @@ void AADisplaySlots::HandleTextButtons()
 
       // Ensure the waveform storage has ceased 
       if(TI->WaveformStorageEnable_CB->IsDown())
-	TI->WaveformStorageEnable_CB->Clicked();
+        TI->WaveformStorageEnable_CB->Clicked();
       
       // Stop data acquisition first
       TheACQManager->StopAcquisition();
@@ -62,7 +62,7 @@ void AADisplaySlots::HandleTextButtons()
       
       // Special handling for acquisition timer 
       if(TheACQManager->GetAcquisitionTimerEnable())
-	TheACQManager->SetAcquisitionTimerEnable(false);
+        TheACQManager->SetAcquisitionTimerEnable(false);
     }
     
     // If acquisition is not presently running then start it
@@ -79,9 +79,9 @@ void AADisplaySlots::HandleTextButtons()
       bool DGChannelEnableSuccess = TheVMEManager->GetDGManager()->CheckForEnabledChannel();
 
       if(DGProgramSuccess and DGChannelEnableSuccess)
-	TheACQManager->StartAcquisition();
+        TheACQManager->StartAcquisition();
       else
-	TI->SetAcquisitionWidgetState(true, kButtonUp);
+        TI->SetAcquisitionWidgetState(true, kButtonUp);
       break;
     }
     break;
@@ -99,18 +99,18 @@ void AADisplaySlots::HandleTextButtons()
     else{
       
       if(TI->TheSettings->WaveformMode and !TI->TheSettings->DisplayNonUpdateable){
-	// Possibly implement future ability to update waveform manually
+        // Possibly implement future ability to update waveform manually
       }
       
       else if(TI->TheSettings->SpectrumMode and !TI->TheSettings->DisplayNonUpdateable){
-	int Channel = TI->TheSettings->SpectrumChannel;
-	TH1F *Spectrum_H = TheACQManager->GetSpectrum(Channel);
-	AAGraphics::GetInstance()->PlotSpectrum(Spectrum_H);
+        int Channel = TI->TheSettings->SpectrumChannel;
+        TH1F *Spectrum_H = TheACQManager->GetSpectrum(Channel);
+        AAGraphics::GetInstance()->PlotSpectrum(Spectrum_H);
       }
       else if(TI->TheSettings->PSDMode and !TI->TheSettings->DisplayNonUpdateable){
-	int Channel = TI->TheSettings->PSDChannel;
-	TH2F *PSDHistogram_H = TheACQManager->GetPSDHistogram(Channel);
-	AAGraphics::GetInstance()->PlotPSDHistogram(PSDHistogram_H);
+        int Channel = TI->TheSettings->PSDChannel;
+        TH2F *PSDHistogram_H = TheACQManager->GetPSDHistogram(Channel);
+        AAGraphics::GetInstance()->PlotPSDHistogram(PSDHistogram_H);
       }
       
       break;

--- a/src/AAGraphics.cc
+++ b/src/AAGraphics.cc
@@ -487,6 +487,9 @@ void AAGraphics::DrawWaveformGraphics(vector<double> &BaselineValue,
   TheCanvas_C->Update();
 }
 
+void AAGraphics::SetupRateGraphics()
+{
+}
 
 void AAGraphics::SetupSpectrumGraphics()
 {
@@ -526,6 +529,9 @@ void AAGraphics::SetupSpectrumGraphics()
   }
 }
 
+void AAGraphics::PlotRate(TH1F *Rate_H)
+{
+}
 
 void AAGraphics::PlotSpectrum(TH1F *Spectrum_H)
 {

--- a/src/AAGraphics.cc
+++ b/src/AAGraphics.cc
@@ -42,7 +42,7 @@ AAGraphics *AAGraphics::GetInstance()
 
 
 AAGraphics::AAGraphics()
-  : MaxWaveformLength(0), WaveformWidth(2), SpectrumWidth(2),
+  : MaxWaveformLength(0), WaveformWidth(2), SpectrumWidth(2), MaxRateSize(0),
     XMin(0.), XMax(1.), YMin(0.), YMax(1.),
     BaselineStart(0), BaselineStop(1),
     WaveformGraphAxes_H(new TH1F), RateGraphAxes_H(new TH1F)
@@ -490,58 +490,123 @@ void AAGraphics::DrawWaveformGraphics(vector<double> &BaselineValue,
   TheCanvas_C->Update();
 }
 
-void AAGraphics::SetupRateGraphics()
-{
-  if(TheSettings->DisplayTitlesEnable){
-    Title = TheSettings->DisplayTitle;
-    XTitle = TheSettings->DisplayXTitle;
-    YTitle = TheSettings->DisplayYTitle;
-    
-    XSize = TheSettings->DisplayXTitleSize;
-    XOffset = TheSettings->DisplayXTitleOffset;
+//void AAGraphics::SetupRateGraphics()
+//{
+//  if(TheSettings->DisplayTitlesEnable){
+//    Title = TheSettings->DisplayTitle;
+//    XTitle = TheSettings->DisplayXTitle;
+//    YTitle = TheSettings->DisplayYTitle;
+//    
+//    XSize = TheSettings->DisplayXTitleSize;
+//    XOffset = TheSettings->DisplayXTitleOffset;
 
-    YSize = TheSettings->DisplayYTitleSize;
-    YOffset = TheSettings->DisplayYTitleOffset;
-  }
-  else{
-    Title = "Trigger rate";
-    string Unit = TheSettings->SpectrumCalibrationUnit;
-    XTitle = "Run time [s]";
+//    YSize = TheSettings->DisplayYTitleSize;
+//    YOffset = TheSettings->DisplayYTitleOffset;
+//  }
+//  else{
+//    Title = "Trigger rate";
+//    string Unit = TheSettings->SpectrumCalibrationUnit;
+//    XTitle = "Run time [s]";
 
-    YTitle = "Triggers/s";
-    
-    XSize = YSize = 0.05;
-    XOffset = 1.1;
-    YOffset = 1.2;
-  }
+//    YTitle = "Triggers/s";
+//    
+//    XSize = YSize = 0.05;
+//    XOffset = 1.1;
+//    YOffset = 1.2;
+//  }
 
-	if (RateGraph)
-		delete RateGraph;
+//	if (RateGraph)
+//		delete RateGraph;
 
-  if (!RateGraph)
-    RateGraph =  new TGraph();
+//  if (!RateGraph)
+//    RateGraph =  new TGraph();
 
-  delete RateGraphAxes_H;
-  RateGraphAxes_H = new TH1F("RateGraphAxes_H",
-				 "A TH1F used to create X and Y axes for rate plotting",
-				 100, 0, MaxWaveformLength);
-  
-  // Set the waveform title and axes properties
-  RateGraphAxes_H->SetTitle(Title.c_str());
-  
-  RateGraphAxes_H->GetXaxis()->SetTitle(XTitle.c_str());
-  RateGraphAxes_H->GetXaxis()->SetTitleSize(XSize);
-  RateGraphAxes_H->GetXaxis()->SetTitleOffset(XOffset);
-  RateGraphAxes_H->GetXaxis()->SetLabelSize(XSize);
-  RateGraphAxes_H->GetXaxis()->SetRangeUser(0, MaxWaveformLength);
-  
-  RateGraphAxes_H->GetYaxis()->SetTitle(YTitle.c_str());
-  RateGraphAxes_H->GetYaxis()->SetTitleSize(YSize);
-  RateGraphAxes_H->GetYaxis()->SetTitleOffset(YOffset);
-  RateGraphAxes_H->GetYaxis()->SetLabelSize(YSize);
+//  delete RateGraphAxes_H;
+//  RateGraphAxes_H = new TH1F("RateGraphAxes_H",
+//				 "A TH1F used to create X and Y axes for rate plotting",
+//				 100, 0, MaxWaveformLength);
+//  
+//  // Set the waveform title and axes properties
+//  RateGraphAxes_H->SetTitle(Title.c_str());
+//  
+//  RateGraphAxes_H->GetXaxis()->SetTitle(XTitle.c_\tstr());
+//  RateGraphAxes_H->GetXaxis()->SetTitleSize(XSize);
+//  RateGraphAxes_H->GetXaxis()->SetTitleOffset(XOffset);
+//  RateGraphAxes_H->GetXaxis()->SetLabelSize(XSize);
+//  RateGraphAxes_H->GetXaxis()->SetRangeUser(0, MaxWaveformLength);
+//  
+//  RateGraphAxes_H->GetYaxis()->SetTitle(YTitle.c_str());
+//  RateGraphAxes_H->GetYaxis()->SetTitleSize(YSize);
+//  RateGraphAxes_H->GetYaxis()->SetTitleOffset(YOffset);
+//  RateGraphAxes_H->GetYaxis()->SetLabelSize(YSize);
 
-  RateGraphAxes_H->SetStats(false);
-}
+//  RateGraphAxes_H->SetStats(false);
+//}
+
+//void AAGraphics::PlotRate(Double_t tss)
+//{
+//  Int_t Channel = TheSettings->RateChannel;
+//  std::list<unsigned int> * data = AAAcquisitionManager::GetInstance()->GetRateList(Channel);
+
+//  // Plotting arrays filled with the data from the list pointer
+//  Double_t ta[data->size()];
+//  Double_t ra[data->size()];
+
+//  unsigned int ci = 0;
+//  Double_t AbsoluteMax = 0;
+//  for (std::list<unsigned int>::iterator it=data->begin(); it != data->end(); ++it){
+//    ta[ci] = ci*TheSettings->RateIntegrationPeriod + tss;
+//    ra[ci] = ((Double_t)*it)/TheSettings->RateIntegrationPeriod;
+//    if (ra[ci]>AbsoluteMax) AbsoluteMax = 1.05*ra[ci];
+//    ci++;
+//  }
+//  
+
+//  RateGraph->SetLineColor(ChColor[Channel]);
+//  RateGraph->SetLineWidth(SpectrumWidth);
+//  RateGraph->SetMarkerStyle(24);
+//  RateGraph->SetMarkerColor(ChColor[Channel]);
+//  RateGraph->SetMarkerSize(0.75);
+//  RateGraph->SetFillColor(ChColor[Channel]);
+
+////  // Set spectrum axes range and lin/log 
+
+//  XMin = ta[data->size()-1] * TheSettings->HorizontalSliderMin;
+//  XMax = ta[data->size()-1] * TheSettings->HorizontalSliderMax;
+//  
+//  (TheSettings->DisplayXAxisInLog) ? 
+//    gPad->SetLogx(true) : gPad->SetLogx(false);
+//  
+//  // Double_t AbsoluteMax = RateGraph->GetMaximum() * 1.05;
+//  YMin = AbsoluteMax * TheSettings->VerticalSliderMin;
+//  YMax = AbsoluteMax * TheSettings->VerticalSliderMax;
+//  
+//  if(TheSettings->DisplayYAxisInLog){
+//    if(YMin == 0) YMin = 1;
+//    gPad->SetLogy(true);
+//  }
+//  else 
+//    gPad->SetLogy(false);
+
+//	RateGraphAxes_H->GetXaxis()->SetRangeUser(XMin,XMax);
+//	RateGraphAxes_H->SetMinimum(YMin);
+//	RateGraphAxes_H->SetMaximum(YMax);
+//	RateGraphAxes_H->Draw("");
+
+//	RateGraph->SetTitle("");
+//  RateGraph->DrawGraph(data->size(),ta,ra,"ALP");
+//  RateGraph->GetXaxis()->SetRangeUser(XMin, XMax);
+//  
+//  // Set plot and axis title text properties
+
+
+//  (TheSettings->DisplayGrid) ? gPad->SetGrid(true, true) : gPad->SetGrid(false, false);
+//  
+//  // If calibration is enabled the draw a vertical line corresponding
+//  // to the current pulse value selected by the triple slider pointer
+
+//  TheCanvas_C->Update();
+//}
 
 void AAGraphics::SetupSpectrumGraphics()
 {
@@ -580,71 +645,6 @@ void AAGraphics::SetupSpectrumGraphics()
     YOffset = 1.2;
   }
 
-}
-
-void AAGraphics::PlotRate(Double_t tss)
-{
-  Int_t Channel = TheSettings->RateChannel;
-  std::list<unsigned int> * data = AAAcquisitionManager::GetInstance()->GetRateList(Channel);
-
-  // Plotting arrays filled with the data from the list pointer
-  Double_t ta[data->size()];
-  Double_t ra[data->size()];
-
-  unsigned int ci = 0;
-  Double_t AbsoluteMax = 0;
-  for (std::list<unsigned int>::iterator it=data->begin(); it != data->end(); ++it){
-    ta[ci] = ci*TheSettings->RateIntegrationPeriod + tss;
-    ra[ci] = ((Double_t)*it)/TheSettings->RateIntegrationPeriod;
-    if (ra[ci]>AbsoluteMax) AbsoluteMax = 1.05*ra[ci];
-    ci++;
-  }
-  
-
-  RateGraph->SetLineColor(ChColor[Channel]);
-  RateGraph->SetLineWidth(SpectrumWidth);
-  RateGraph->SetMarkerStyle(24);
-  RateGraph->SetMarkerColor(ChColor[Channel]);
-  RateGraph->SetMarkerSize(0.75);
-  RateGraph->SetFillColor(ChColor[Channel]);
-
-//  // Set spectrum axes range and lin/log 
-
-  XMin = ta[data->size()-1] * TheSettings->HorizontalSliderMin;
-  XMax = ta[data->size()-1] * TheSettings->HorizontalSliderMax;
-  
-  (TheSettings->DisplayXAxisInLog) ? 
-    gPad->SetLogx(true) : gPad->SetLogx(false);
-  
-  // Double_t AbsoluteMax = RateGraph->GetMaximum() * 1.05;
-  YMin = AbsoluteMax * TheSettings->VerticalSliderMin;
-  YMax = AbsoluteMax * TheSettings->VerticalSliderMax;
-  
-  if(TheSettings->DisplayYAxisInLog){
-    if(YMin == 0) YMin = 1;
-    gPad->SetLogy(true);
-  }
-  else 
-    gPad->SetLogy(false);
-
-	RateGraphAxes_H->GetXaxis()->SetRangeUser(XMin,XMax);
-	RateGraphAxes_H->SetMinimum(YMin);
-	RateGraphAxes_H->SetMaximum(YMax);
-	RateGraphAxes_H->Draw("");
-
-	RateGraph->SetTitle("");
-  RateGraph->DrawGraph(data->size(),ta,ra,"ALP");
-  RateGraph->GetXaxis()->SetRangeUser(XMin, XMax);
-  
-  // Set plot and axis title text properties
-
-
-  (TheSettings->DisplayGrid) ? gPad->SetGrid(true, true) : gPad->SetGrid(false, false);
-  
-  // If calibration is enabled the draw a vertical line corresponding
-  // to the current pulse value selected by the triple slider pointer
-
-  TheCanvas_C->Update();
 }
 
 void AAGraphics::PlotSpectrum(TH1F *Spectrum_H)
@@ -827,4 +827,138 @@ void AAGraphics::PlotCalibration(int Channel)
   CalibrationCurve->Draw("ALP");
   
   CalibrationCanvas_C->Update();
+}
+
+void AAGraphics::SetupRateGraphics()
+{
+  // Clear and reserve space for the plotting vectors (so that no dynamic
+  // changes to their size in memory are needed during readout)
+  MaxRateSize = TheSettings->RateNumPeriods;
+  timeR.clear();
+  rateR.clear();
+  timeR.reserve(MaxRateSize);
+  rateR.reserve(MaxRateSize);
+
+  if(TheSettings->DisplayTitlesEnable){
+    Title = TheSettings->DisplayTitle;
+    XTitle = TheSettings->DisplayXTitle;
+    YTitle = TheSettings->DisplayYTitle;
+    
+    XSize = TheSettings->DisplayXTitleSize;
+    XOffset = TheSettings->DisplayXTitleOffset;
+
+    YSize = TheSettings->DisplayYTitleSize;
+    YOffset = TheSettings->DisplayYTitleOffset;
+  }
+  else{
+    Title = "Trigger rate";
+    string Unit = TheSettings->SpectrumCalibrationUnit;
+    XTitle = "Run time [s]";
+
+    YTitle = "Triggers/s";
+    
+    XSize = YSize = 0.05;
+    XOffset = 1.1;
+    YOffset = 1.2;
+  }
+
+  // Similar approach to how the waveforms are plotted using TGraph objects:
+  //
+  // 0. Previous TGraph objects are deleted to prevent memory leak
+  // 1. New TGraph objects are created for all channels
+  // 3. Static graphical attributes are set for each channel's TGraph
+  
+  if (RateGraph)
+    delete RateGraph;
+ 
+  // Create a new TGraph representing the rate plot
+  RateGraph = new TGraph;
+
+  Int_t ch = TheSettings->RateChannel;
+
+  // Set the static rate plot graphical options
+  RateGraph->SetLineColor(ChColor[ch]);
+  RateGraph->SetLineWidth(WaveformWidth);  // Not important enough to change
+  RateGraph->SetMarkerStyle(24);           // to use a separate value from waveform
+  RateGraph->SetMarkerSize(0.75);
+  RateGraph->SetMarkerColor(ChColor[ch]);
+  RateGraph->SetFillColor(ChColor[ch]);
+  
+  // Delete and recreate a TH1F object that is used to create the X
+  // and Y axes for plotting the trigger rate. The title/xtitle/ytitle
+  // and other graphical options should be set here.
+  
+  delete RateGraphAxes_H;
+  RateGraphAxes_H = new TH1F("RateGraphAxes_H",
+				 "A TH1F used to create X and Y axes for rate plotting",
+				 MaxRateSize, 0, MaxRateSize);
+  
+  // Set the rate title and axes properties
+  RateGraphAxes_H->SetTitle(Title.c_str());
+  
+  RateGraphAxes_H->GetXaxis()->SetTitle(XTitle.c_str());
+  RateGraphAxes_H->GetXaxis()->SetTitleSize(XSize);
+  RateGraphAxes_H->GetXaxis()->SetTitleOffset(XOffset);
+  RateGraphAxes_H->GetXaxis()->SetLabelSize(XSize);
+  RateGraphAxes_H->GetXaxis()->SetRangeUser(0, MaxRateSize);
+  
+  RateGraphAxes_H->GetYaxis()->SetTitle(YTitle.c_str());
+  RateGraphAxes_H->GetYaxis()->SetTitleSize(YSize);
+  RateGraphAxes_H->GetYaxis()->SetTitleOffset(YOffset);
+  RateGraphAxes_H->GetYaxis()->SetLabelSize(YSize);
+
+  RateGraphAxes_H->SetStats(false);
+}
+
+
+void AAGraphics::PlotRate(Double_t tss)
+{
+  Int_t Channel = TheSettings->RateChannel;
+  std::list<unsigned int> * data = AAAcquisitionManager::GetInstance()->GetRateList(Channel);
+
+  // Prevent plotting if there is no data
+  if(data->size() == 0)
+    return;
+
+  timeR.clear();
+  rateR.clear();
+
+  // Fill the plot vectors, get the max rate value
+  unsigned int ci = 0;
+  Double_t AbsoluteMax = 0;
+  for (std::list<unsigned int>::iterator it=data->begin(); it != data->end(); ++it){
+    timeR.push_back(ci*TheSettings->RateIntegrationPeriod + tss);
+    rateR.push_back(((Double_t)*it)/TheSettings->RateIntegrationPeriod);
+    if (rateR.back()>AbsoluteMax) AbsoluteMax = 1.05*rateR.back();
+    ci++;
+  }
+
+  // Set the horiz. and vert. min/max ranges of the rate graph.
+
+  XMin = MaxRateSize * TheSettings->HorizontalSliderMin;
+  XMax = MaxRateSize * TheSettings->HorizontalSliderMax;
+  RateGraph->GetXaxis()->SetRangeUser(XMin, XMax);
+
+  (TheSettings->DisplayXAxisInLog) ? 
+    gPad->SetLogx(true) : gPad->SetLogx(false);
+  
+  YMin = AbsoluteMax * TheSettings->VerticalSliderMin;
+  YMax = AbsoluteMax * TheSettings->VerticalSliderMax;
+    
+  if(TheSettings->DisplayYAxisInLog){
+    if(YMin == 0) YMin = 1;
+    gPad->SetLogy(true);
+  }
+  else
+    gPad->SetLogy(false);
+    
+
+  RateGraphAxes_H->GetXaxis()->SetRangeUser(XMin,XMax);
+  RateGraphAxes_H->SetMinimum(YMin);
+  RateGraphAxes_H->SetMaximum(YMax);
+  RateGraphAxes_H->Draw("");
+
+  RateGraph->DrawGraph(data->size(),&timeR[0],&rateR[0],"ALP");
+
+  (TheSettings->DisplayGrid) ? gPad->SetGrid(true, true) : gPad->SetGrid(false, false);
 }

--- a/src/AAGraphics.cc
+++ b/src/AAGraphics.cc
@@ -564,78 +564,68 @@ void AAGraphics::PlotRate(Double_t tss)
   std::list<unsigned int> * data = AAAcquisitionManager::GetInstance()->GetRateList(Channel);
 
   // Plotting arrays filled with the data from the list pointer
-  
+  Double_t ta[data->size()];
+  Double_t ra[data->size()];
+
+  unsigned int ci = 0;
+  for (std::list<unsigned int>::iterator it=data->begin(); it != data->end(); ++it){
+    ta[ci] = ci*TheSettings->RateIntegrationPeriod + tss;
+    ra[ci++] = ((Double_t)*it)/TheSettings->RateIntegrationPeriod;
+  }
   
 
-//  Spectrum_H->SetLineColor(ChColor[Channel]);
-//  Spectrum_H->SetLineWidth(SpectrumWidth);
-//  Spectrum_H->SetMarkerStyle(24);
-//  Spectrum_H->SetMarkerColor(ChColor[Channel]);
-//  Spectrum_H->SetMarkerSize(0.75);
-//  Spectrum_H->SetFillColor(ChColor[Channel]);
-//  
-//  if(TheSettings->SpectrumWithLine){
-//    Spectrum_H->SetFillStyle(0);
-//    Spectrum_H->Draw("");
-//  }
-//  else if(TheSettings->SpectrumWithMarkers)
-//    Spectrum_H->Draw("E1");
-//  else
-//    Spectrum_H->Draw("B");
+  RateGraph->SetLineColor(ChColor[Channel]);
+  RateGraph->SetLineWidth(SpectrumWidth);
+  RateGraph->SetMarkerStyle(24);
+  RateGraph->SetMarkerColor(ChColor[Channel]);
+  RateGraph->SetMarkerSize(0.75);
+  RateGraph->SetFillColor(ChColor[Channel]);
+
+  RateGraph->DrawGraph(data->size(),ta,ra,"ALP");
 
 //  // Set spectrum axes range and lin/log 
 
-//  XMin = TheSettings->SpectrumMaxBin * TheSettings->HorizontalSliderMin;
-//  XMax = TheSettings->SpectrumMaxBin * TheSettings->HorizontalSliderMax;
-//  Spectrum_H->GetXaxis()->SetRangeUser(XMin, XMax);
-//  
-//  (TheSettings->DisplayXAxisInLog) ? 
-//    gPad->SetLogx(true) : gPad->SetLogx(false);
-//  
-//  Int_t AbsoluteMax = Spectrum_H->GetBinContent(Spectrum_H->GetMaximumBin()) * 1.05;
-//  YMin = AbsoluteMax * TheSettings->VerticalSliderMin;
-//  YMax = AbsoluteMax * TheSettings->VerticalSliderMax;
-//  
-//  if(TheSettings->DisplayYAxisInLog){
-//    if(YMin == 0) YMin = 1;
-//    gPad->SetLogy(true);
-//  }
-//  else 
-//    gPad->SetLogy(false);
-//  
-//  Spectrum_H->SetMinimum(YMin);
-//  Spectrum_H->SetMaximum(YMax);
+  XMin = ta[data->size()-1] * TheSettings->HorizontalSliderMin;
+  XMax = ta[data->size()-1] * TheSettings->HorizontalSliderMax;
+  RateGraph->GetXaxis()->SetRangeUser(XMin, XMax);
+  
+  (TheSettings->DisplayXAxisInLog) ? 
+    gPad->SetLogx(true) : gPad->SetLogx(false);
+  
+  Double_t AbsoluteMax = RateGraph->GetMaximum() * 1.05;
+  YMin = AbsoluteMax * TheSettings->VerticalSliderMin;
+  YMax = AbsoluteMax * TheSettings->VerticalSliderMax;
+  
+  if(TheSettings->DisplayYAxisInLog){
+    if(YMin == 0) YMin = 1;
+    gPad->SetLogy(true);
+  }
+  else 
+    gPad->SetLogy(false);
+  
+  RateGraph->SetMinimum(YMin);
+  RateGraph->SetMaximum(YMax);
 
-//  // Set plot and axis title text properties
+  // Set plot and axis title text properties
 
-//  Spectrum_H->SetTitle(Title.c_str());
-//  
-//  Spectrum_H->GetXaxis()->SetTitle(XTitle.c_str());
-//  Spectrum_H->GetXaxis()->SetTitleSize(XSize);
-//  Spectrum_H->GetXaxis()->SetTitleOffset(XOffset);
-//  Spectrum_H->GetXaxis()->SetLabelSize(XSize);
+  RateGraph->SetTitle(Title.c_str());
+  
+  RateGraph->GetXaxis()->SetTitle(XTitle.c_str());
+  RateGraph->GetXaxis()->SetTitleSize(XSize);
+  RateGraph->GetXaxis()->SetTitleOffset(XOffset);
+  RateGraph->GetXaxis()->SetLabelSize(XSize);
 
-//  Spectrum_H->GetYaxis()->SetTitle(YTitle.c_str());
-//  Spectrum_H->GetYaxis()->SetTitleSize(YSize);
-//  Spectrum_H->GetYaxis()->SetTitleOffset(YOffset);
-//  Spectrum_H->GetYaxis()->SetLabelSize(YSize);
+  RateGraph->GetYaxis()->SetTitle(YTitle.c_str());
+  RateGraph->GetYaxis()->SetTitleSize(YSize);
+  RateGraph->GetYaxis()->SetTitleOffset(YOffset);
+  RateGraph->GetYaxis()->SetLabelSize(YSize);
 
-//  (TheSettings->DisplayLegend) ? Spectrum_H->SetStats(true) : Spectrum_H->SetStats(false);
-//  (TheSettings->DisplayGrid) ? gPad->SetGrid(true, true) : gPad->SetGrid(false, false);
-//  
-//  // If calibration is enabled the draw a vertical line corresponding
-//  // to the current pulse value selected by the triple slider pointer
+  (TheSettings->DisplayGrid) ? gPad->SetGrid(true, true) : gPad->SetGrid(false, false);
+  
+  // If calibration is enabled the draw a vertical line corresponding
+  // to the current pulse value selected by the triple slider pointer
 
-//  if(TheSettings->SpectrumCalibrationEnable){
-//    Double_t PulseValue = TheSettings->SpectrumMaxBin *
-//      TheSettings->HorizontalSliderPtr;
-//    
-//    SpectrumCalibration_L->DrawLine(PulseValue,
-//				    YMin,
-//				    PulseValue,
-//				    YMax);
-//  }
-//  TheCanvas_C->Update();
+  TheCanvas_C->Update();
 }
 
 void AAGraphics::PlotSpectrum(TH1F *Spectrum_H)

--- a/src/AAGraphics.cc
+++ b/src/AAGraphics.cc
@@ -795,6 +795,8 @@ void AAGraphics::SetupRateGraphics()
 
 void AAGraphics::PlotRate(Double_t tss)
 {
+	gPad->Clear();
+
   Int_t Channel = TheSettings->RateChannel;
   std::list<unsigned int> * data = AAAcquisitionManager::GetInstance()->GetRateList(Channel);
 
@@ -841,8 +843,8 @@ void AAGraphics::PlotRate(Double_t tss)
   RateGraphAxes_H->SetMaximum(YMax);
   //RateGraphAxes_H->Draw("");
 
-  RateGraph->SetTitle("");
   RateGraph->DrawGraph(data->size(),&timeR[0],&rateR[0],"ALP");
+  RateGraph->SetTitle("");
 
   (TheSettings->DisplayGrid) ? gPad->SetGrid(true, true) : gPad->SetGrid(false, false);
 

--- a/src/AAGraphics.cc
+++ b/src/AAGraphics.cc
@@ -25,6 +25,7 @@ using namespace boost::assign;
 #include <sstream>
 #include <numeric>
 #include <cmath>
+#include <list>
 
 // ADAQAcquisition
 #include "AAGraphics.hh"
@@ -136,6 +137,8 @@ AAGraphics::AAGraphics()
     
     Waveform_LG->AddEntry(Line, LineName.c_str(), "L");
   }
+
+  RateGraph = NULL;
 }
 
 
@@ -489,7 +492,31 @@ void AAGraphics::DrawWaveformGraphics(vector<double> &BaselineValue,
 
 void AAGraphics::SetupRateGraphics()
 {
-  // AAAcquisitionManager::GetInstance()->SetupRateVector();
+  if(TheSettings->DisplayTitlesEnable){
+    Title = TheSettings->DisplayTitle;
+    XTitle = TheSettings->DisplayXTitle;
+    YTitle = TheSettings->DisplayYTitle;
+    
+    XSize = TheSettings->DisplayXTitleSize;
+    XOffset = TheSettings->DisplayXTitleOffset;
+
+    YSize = TheSettings->DisplayYTitleSize;
+    YOffset = TheSettings->DisplayYTitleOffset;
+  }
+  else{
+    Title = "Trigger rate";
+    string Unit = TheSettings->SpectrumCalibrationUnit;
+    XTitle = "Run time [s]";
+
+    YTitle = "Triggers/s";
+    
+    XSize = YSize = 0.05;
+    XOffset = 1.1;
+    YOffset = 1.2;
+  }
+
+  if (!RateGraph)
+    RateGraph =  new TGraph();
 }
 
 void AAGraphics::SetupSpectrumGraphics()
@@ -528,11 +555,17 @@ void AAGraphics::SetupSpectrumGraphics()
     XOffset = 1.1;
     YOffset = 1.2;
   }
+
 }
 
-void AAGraphics::PlotRate(TGraph *Rate_P)
+void AAGraphics::PlotRate(Double_t tss)
 {
   Int_t Channel = TheSettings->RateChannel;
+  std::list<unsigned int> * data = AAAcquisitionManager::GetInstance()->GetRateList(Channel);
+
+  // Plotting arrays filled with the data from the list pointer
+  
+  
 
 //  Spectrum_H->SetLineColor(ChColor[Channel]);
 //  Spectrum_H->SetLineWidth(SpectrumWidth);

--- a/src/AAGraphics.cc
+++ b/src/AAGraphics.cc
@@ -490,124 +490,6 @@ void AAGraphics::DrawWaveformGraphics(vector<double> &BaselineValue,
   TheCanvas_C->Update();
 }
 
-//void AAGraphics::SetupRateGraphics()
-//{
-//  if(TheSettings->DisplayTitlesEnable){
-//    Title = TheSettings->DisplayTitle;
-//    XTitle = TheSettings->DisplayXTitle;
-//    YTitle = TheSettings->DisplayYTitle;
-//    
-//    XSize = TheSettings->DisplayXTitleSize;
-//    XOffset = TheSettings->DisplayXTitleOffset;
-
-//    YSize = TheSettings->DisplayYTitleSize;
-//    YOffset = TheSettings->DisplayYTitleOffset;
-//  }
-//  else{
-//    Title = "Trigger rate";
-//    string Unit = TheSettings->SpectrumCalibrationUnit;
-//    XTitle = "Run time [s]";
-
-//    YTitle = "Triggers/s";
-//    
-//    XSize = YSize = 0.05;
-//    XOffset = 1.1;
-//    YOffset = 1.2;
-//  }
-
-//	if (RateGraph)
-//		delete RateGraph;
-
-//  if (!RateGraph)
-//    RateGraph =  new TGraph();
-
-//  delete RateGraphAxes_H;
-//  RateGraphAxes_H = new TH1F("RateGraphAxes_H",
-//				 "A TH1F used to create X and Y axes for rate plotting",
-//				 100, 0, MaxWaveformLength);
-//  
-//  // Set the waveform title and axes properties
-//  RateGraphAxes_H->SetTitle(Title.c_str());
-//  
-//  RateGraphAxes_H->GetXaxis()->SetTitle(XTitle.c_\tstr());
-//  RateGraphAxes_H->GetXaxis()->SetTitleSize(XSize);
-//  RateGraphAxes_H->GetXaxis()->SetTitleOffset(XOffset);
-//  RateGraphAxes_H->GetXaxis()->SetLabelSize(XSize);
-//  RateGraphAxes_H->GetXaxis()->SetRangeUser(0, MaxWaveformLength);
-//  
-//  RateGraphAxes_H->GetYaxis()->SetTitle(YTitle.c_str());
-//  RateGraphAxes_H->GetYaxis()->SetTitleSize(YSize);
-//  RateGraphAxes_H->GetYaxis()->SetTitleOffset(YOffset);
-//  RateGraphAxes_H->GetYaxis()->SetLabelSize(YSize);
-
-//  RateGraphAxes_H->SetStats(false);
-//}
-
-//void AAGraphics::PlotRate(Double_t tss)
-//{
-//  Int_t Channel = TheSettings->RateChannel;
-//  std::list<unsigned int> * data = AAAcquisitionManager::GetInstance()->GetRateList(Channel);
-
-//  // Plotting arrays filled with the data from the list pointer
-//  Double_t ta[data->size()];
-//  Double_t ra[data->size()];
-
-//  unsigned int ci = 0;
-//  Double_t AbsoluteMax = 0;
-//  for (std::list<unsigned int>::iterator it=data->begin(); it != data->end(); ++it){
-//    ta[ci] = ci*TheSettings->RateIntegrationPeriod + tss;
-//    ra[ci] = ((Double_t)*it)/TheSettings->RateIntegrationPeriod;
-//    if (ra[ci]>AbsoluteMax) AbsoluteMax = 1.05*ra[ci];
-//    ci++;
-//  }
-//  
-
-//  RateGraph->SetLineColor(ChColor[Channel]);
-//  RateGraph->SetLineWidth(SpectrumWidth);
-//  RateGraph->SetMarkerStyle(24);
-//  RateGraph->SetMarkerColor(ChColor[Channel]);
-//  RateGraph->SetMarkerSize(0.75);
-//  RateGraph->SetFillColor(ChColor[Channel]);
-
-////  // Set spectrum axes range and lin/log 
-
-//  XMin = ta[data->size()-1] * TheSettings->HorizontalSliderMin;
-//  XMax = ta[data->size()-1] * TheSettings->HorizontalSliderMax;
-//  
-//  (TheSettings->DisplayXAxisInLog) ? 
-//    gPad->SetLogx(true) : gPad->SetLogx(false);
-//  
-//  // Double_t AbsoluteMax = RateGraph->GetMaximum() * 1.05;
-//  YMin = AbsoluteMax * TheSettings->VerticalSliderMin;
-//  YMax = AbsoluteMax * TheSettings->VerticalSliderMax;
-//  
-//  if(TheSettings->DisplayYAxisInLog){
-//    if(YMin == 0) YMin = 1;
-//    gPad->SetLogy(true);
-//  }
-//  else 
-//    gPad->SetLogy(false);
-
-//	RateGraphAxes_H->GetXaxis()->SetRangeUser(XMin,XMax);
-//	RateGraphAxes_H->SetMinimum(YMin);
-//	RateGraphAxes_H->SetMaximum(YMax);
-//	RateGraphAxes_H->Draw("");
-
-//	RateGraph->SetTitle("");
-//  RateGraph->DrawGraph(data->size(),ta,ra,"ALP");
-//  RateGraph->GetXaxis()->SetRangeUser(XMin, XMax);
-//  
-//  // Set plot and axis title text properties
-
-
-//  (TheSettings->DisplayGrid) ? gPad->SetGrid(true, true) : gPad->SetGrid(false, false);
-//  
-//  // If calibration is enabled the draw a vertical line corresponding
-//  // to the current pulse value selected by the triple slider pointer
-
-//  TheCanvas_C->Update();
-//}
-
 void AAGraphics::SetupSpectrumGraphics()
 {
   if(TheSettings->DisplayTitlesEnable){
@@ -900,7 +782,7 @@ void AAGraphics::SetupRateGraphics()
   RateGraphAxes_H->GetXaxis()->SetTitleSize(XSize);
   RateGraphAxes_H->GetXaxis()->SetTitleOffset(XOffset);
   RateGraphAxes_H->GetXaxis()->SetLabelSize(XSize);
-  RateGraphAxes_H->GetXaxis()->SetRangeUser(0, MaxRateSize);
+  RateGraphAxes_H->GetXaxis()->SetRangeUser(0, TheSettings->RateDisplayPeriod);
   
   RateGraphAxes_H->GetYaxis()->SetTitle(YTitle.c_str());
   RateGraphAxes_H->GetYaxis()->SetTitleSize(YSize);
@@ -954,11 +836,15 @@ void AAGraphics::PlotRate(Double_t tss)
     
 
   RateGraphAxes_H->GetXaxis()->SetRangeUser(XMin,XMax);
+  RateGraphAxes_H->GetYaxis()->SetRangeUser(YMin,YMax);
   RateGraphAxes_H->SetMinimum(YMin);
   RateGraphAxes_H->SetMaximum(YMax);
-  RateGraphAxes_H->Draw("");
+  //RateGraphAxes_H->Draw("");
 
+  RateGraph->SetTitle("");
   RateGraph->DrawGraph(data->size(),&timeR[0],&rateR[0],"ALP");
 
   (TheSettings->DisplayGrid) ? gPad->SetGrid(true, true) : gPad->SetGrid(false, false);
+
+  TheCanvas_C->Update();
 }

--- a/src/AAGraphics.cc
+++ b/src/AAGraphics.cc
@@ -489,6 +489,7 @@ void AAGraphics::DrawWaveformGraphics(vector<double> &BaselineValue,
 
 void AAGraphics::SetupRateGraphics()
 {
+  // AAAcquisitionManager::GetInstance()->SetupRateVector();
 }
 
 void AAGraphics::SetupSpectrumGraphics()
@@ -517,9 +518,9 @@ void AAGraphics::SetupSpectrumGraphics()
     }
     else{
       if(TheSettings->SpectrumPulseHeight)
-	XTitle = "Pulse height [ADC]";
+        XTitle = "Pulse height [ADC]";
       else if(TheSettings->SpectrumPulseArea)
-	XTitle = "Pulse area [ADC]";
+        XTitle = "Pulse area [ADC]";
     }
     YTitle = "Counts";
     
@@ -529,8 +530,79 @@ void AAGraphics::SetupSpectrumGraphics()
   }
 }
 
-void AAGraphics::PlotRate(TH1F *Rate_H)
+void AAGraphics::PlotRate(TGraph *Rate_P)
 {
+  Int_t Channel = TheSettings->RateChannel;
+
+//  Spectrum_H->SetLineColor(ChColor[Channel]);
+//  Spectrum_H->SetLineWidth(SpectrumWidth);
+//  Spectrum_H->SetMarkerStyle(24);
+//  Spectrum_H->SetMarkerColor(ChColor[Channel]);
+//  Spectrum_H->SetMarkerSize(0.75);
+//  Spectrum_H->SetFillColor(ChColor[Channel]);
+//  
+//  if(TheSettings->SpectrumWithLine){
+//    Spectrum_H->SetFillStyle(0);
+//    Spectrum_H->Draw("");
+//  }
+//  else if(TheSettings->SpectrumWithMarkers)
+//    Spectrum_H->Draw("E1");
+//  else
+//    Spectrum_H->Draw("B");
+
+//  // Set spectrum axes range and lin/log 
+
+//  XMin = TheSettings->SpectrumMaxBin * TheSettings->HorizontalSliderMin;
+//  XMax = TheSettings->SpectrumMaxBin * TheSettings->HorizontalSliderMax;
+//  Spectrum_H->GetXaxis()->SetRangeUser(XMin, XMax);
+//  
+//  (TheSettings->DisplayXAxisInLog) ? 
+//    gPad->SetLogx(true) : gPad->SetLogx(false);
+//  
+//  Int_t AbsoluteMax = Spectrum_H->GetBinContent(Spectrum_H->GetMaximumBin()) * 1.05;
+//  YMin = AbsoluteMax * TheSettings->VerticalSliderMin;
+//  YMax = AbsoluteMax * TheSettings->VerticalSliderMax;
+//  
+//  if(TheSettings->DisplayYAxisInLog){
+//    if(YMin == 0) YMin = 1;
+//    gPad->SetLogy(true);
+//  }
+//  else 
+//    gPad->SetLogy(false);
+//  
+//  Spectrum_H->SetMinimum(YMin);
+//  Spectrum_H->SetMaximum(YMax);
+
+//  // Set plot and axis title text properties
+
+//  Spectrum_H->SetTitle(Title.c_str());
+//  
+//  Spectrum_H->GetXaxis()->SetTitle(XTitle.c_str());
+//  Spectrum_H->GetXaxis()->SetTitleSize(XSize);
+//  Spectrum_H->GetXaxis()->SetTitleOffset(XOffset);
+//  Spectrum_H->GetXaxis()->SetLabelSize(XSize);
+
+//  Spectrum_H->GetYaxis()->SetTitle(YTitle.c_str());
+//  Spectrum_H->GetYaxis()->SetTitleSize(YSize);
+//  Spectrum_H->GetYaxis()->SetTitleOffset(YOffset);
+//  Spectrum_H->GetYaxis()->SetLabelSize(YSize);
+
+//  (TheSettings->DisplayLegend) ? Spectrum_H->SetStats(true) : Spectrum_H->SetStats(false);
+//  (TheSettings->DisplayGrid) ? gPad->SetGrid(true, true) : gPad->SetGrid(false, false);
+//  
+//  // If calibration is enabled the draw a vertical line corresponding
+//  // to the current pulse value selected by the triple slider pointer
+
+//  if(TheSettings->SpectrumCalibrationEnable){
+//    Double_t PulseValue = TheSettings->SpectrumMaxBin *
+//      TheSettings->HorizontalSliderPtr;
+//    
+//    SpectrumCalibration_L->DrawLine(PulseValue,
+//				    YMin,
+//				    PulseValue,
+//				    YMax);
+//  }
+//  TheCanvas_C->Update();
 }
 
 void AAGraphics::PlotSpectrum(TH1F *Spectrum_H)

--- a/src/AAInterface.cc
+++ b/src/AAInterface.cc
@@ -2507,6 +2507,34 @@ void AAInterface::FillAcquisitionFrame()
 				   new TGLayoutHints(kLHintsNormal, 0,3,3,-2));
   DrawSpectrumWithBars_RB->Connect("Clicked()", "AASubtabSlots", SubtabSlots, "HandleRadioButtons()");
 
+//
+  TGGroupFrame *RateDrawOptions_GF = new TGGroupFrame(DisplaySettings_GF, "Rate plot options", kVerticalFrame);
+  DisplaySettings_GF->AddFrame(RateDrawOptions_GF,
+			       new TGLayoutHints(kLHintsNormal, 0,0,5,0));
+  
+  RateDrawOptions_GF->AddFrame(RatePlotDisp_NEL = new ADAQNumberEntryWithLabel(RateDrawOptions_GF, "Rate display period (s)", -1),
+			      new TGLayoutHints(kLHintsNormal, 0,0,5,0));
+  RatePlotDisp_NEL->GetEntry()->SetNumStyle(TGNumberFormat::kNESReal);
+  RatePlotDisp_NEL->GetEntry()->SetNumAttr(TGNumberFormat::kNEAPositive);
+  RatePlotDisp_NEL->GetEntry()->Resize(50,20);
+  RatePlotDisp_NEL->GetEntry()->SetNumber(60);
+
+  RateDrawOptions_GF->AddFrame(RatePlotPeriod_NEL = new ADAQNumberEntryWithLabel(RateDrawOptions_GF, "Rate integration period (s)", -1),
+			      new TGLayoutHints(kLHintsNormal, 0,0,5,0));
+  RatePlotPeriod_NEL->GetEntry()->SetNumStyle(TGNumberFormat::kNESReal);
+  RatePlotPeriod_NEL->GetEntry()->SetNumAttr(TGNumberFormat::kNEAPositive);
+  RatePlotPeriod_NEL->GetEntry()->Resize(50,20);
+  RatePlotPeriod_NEL->GetEntry()->SetNumber(2);
+
+
+
+  DrawSpectrumWithLine_RB->Connect("Clicked()", "AASubtabSlots", SubtabSlots, "HandleRadioButtons()");
+  DrawSpectrumWithLine_RB->SetState(kButtonDown);
+  
+
+
+//
+
   
   TGGroupFrame *DisplayControl_GF = new TGGroupFrame(GraphicsSubframe, "Control", kVerticalFrame);
   DisplayControl_GF->SetTitlePos(TGGroupFrame::kCenter);
@@ -3025,6 +3053,9 @@ void AAInterface::SaveSettings()
     TheSettings->SpectrumWithLine = DrawSpectrumWithLine_RB->IsDown();
     TheSettings->SpectrumWithMarkers = DrawSpectrumWithMarkers_RB->IsDown();
     TheSettings->SpectrumWithBars = DrawSpectrumWithBars_RB->IsDown();
+
+    TheSettings->RateIntegrationPeriod = RatePlotPeriod_NEL->GetEntry()->GetNumber();
+    TheSettings->RateDisplayPeriod = RatePlotPeriod_NEL->GetEntry()->GetNumber();
   
     TheSettings->SpectrumRefreshRate = SpectrumRefreshRate_NEL->GetEntry()->GetIntNumber();
 

--- a/src/AAInterface.cc
+++ b/src/AAInterface.cc
@@ -2511,6 +2511,13 @@ void AAInterface::FillAcquisitionFrame()
   TGGroupFrame *RateDrawOptions_GF = new TGGroupFrame(DisplaySettings_GF, "Rate plot options", kVerticalFrame);
   DisplaySettings_GF->AddFrame(RateDrawOptions_GF,
 			       new TGLayoutHints(kLHintsNormal, 0,0,5,0));
+
+  RateDrawOptions_GF->AddFrame(RateChannel_CBL = new ADAQComboBoxWithLabel(RateDrawOptions_GF, "", RateDrawOptions_CBL_ID),
+				 new TGLayoutHints(kLHintsNormal,0,0,5,5));
+  for(uint32_t ch=0; ch<NumDGChannels; ch++)
+    RateChannel_CBL->GetComboBox()->AddEntry(DGChannelLabels[ch].c_str(),ch);
+  RateChannel_CBL->GetComboBox()->Select(0);
+  RateChannel_CBL->GetComboBox()->Connect("Selected(int,int)", "AASubtabSlots", SubtabSlots, "HandleComboBoxes(int,int)");
   
   RateDrawOptions_GF->AddFrame(RatePlotDisp_NEL = new ADAQNumberEntryWithLabel(RateDrawOptions_GF, "Rate display period (s)", -1),
 			      new TGLayoutHints(kLHintsNormal, 0,0,5,0));
@@ -2524,7 +2531,14 @@ void AAInterface::FillAcquisitionFrame()
   RatePlotPeriod_NEL->GetEntry()->SetNumStyle(TGNumberFormat::kNESReal);
   RatePlotPeriod_NEL->GetEntry()->SetNumAttr(TGNumberFormat::kNEAPositive);
   RatePlotPeriod_NEL->GetEntry()->Resize(50,20);
-  RatePlotPeriod_NEL->GetEntry()->SetNumber(2);
+  RatePlotPeriod_NEL->GetEntry()->SetNumber(1);
+
+  RateDrawOptions_GF->AddFrame(RateTSResolution_NEL = new ADAQNumberEntryWithLabel(RateDrawOptions_GF, "Timestamp Resolution (ns)", -1),
+			      new TGLayoutHints(kLHintsNormal, 0,0,5,0));
+  RateTSResolution_NEL->GetEntry()->SetNumStyle(TGNumberFormat::kNESReal);
+  RateTSResolution_NEL->GetEntry()->SetNumAttr(TGNumberFormat::kNEAPositive);
+  RateTSResolution_NEL->GetEntry()->Resize(50,20);
+  RateTSResolution_NEL->GetEntry()->SetNumber(4);
 
 
 
@@ -3054,9 +3068,11 @@ void AAInterface::SaveSettings()
     TheSettings->SpectrumWithMarkers = DrawSpectrumWithMarkers_RB->IsDown();
     TheSettings->SpectrumWithBars = DrawSpectrumWithBars_RB->IsDown();
 
+    TheSettings->RateChannel = RateChannel_CBL->GetComboBox()->GetSelected();
     TheSettings->RateIntegrationPeriod = RatePlotPeriod_NEL->GetEntry()->GetNumber();
     TheSettings->RateDisplayPeriod = RatePlotPeriod_NEL->GetEntry()->GetNumber();
-  
+    TheSettings->RateTSResolution = RateTSResolution_NEL->GetEntry()->GetNumber();
+
     TheSettings->SpectrumRefreshRate = SpectrumRefreshRate_NEL->GetEntry()->GetIntNumber();
 
     TheSettings->DisplayContinuous = DisplayContinuous_RB->IsDown();
@@ -3450,6 +3466,7 @@ void AAInterface::LoadSettingsFromFile()
       SpectrumUseCalibrationSlider_CB->SetState(kButtonUp);
 
     // TheSettings->SpectrumCalibrationUnit = SpectrumCalibrationUnit_CBL->GetComboBox()->GetSelectedEntry()->GetTitle();
+
 
     ///////////////////////
     // Pulse discrimination

--- a/src/AAInterface.cc
+++ b/src/AAInterface.cc
@@ -1666,6 +1666,9 @@ void AAInterface::FillAcquisitionFrame()
   AQPSDHistogram_RB = new TGRadioButton(DGScopeMode_BG, "PSD Histogram", AQPSDHistogram_RB_ID);
   AQPSDHistogram_RB->Connect("Clicked()", "AASubtabSlots", SubtabSlots, "HandleRadioButtons()");
   
+  AQRate_RB = new TGRadioButton(DGScopeMode_BG, "Trigger Rate Plot", AQRate_RB_ID);
+  AQRate_RB->Connect("Clicked()", "AASubtabSlots", SubtabSlots, "HandleRadioButtons()");
+
   DGScopeMode_BG->Show();
 
 
@@ -2625,6 +2628,7 @@ void AAInterface::SetAcquisitionWidgetState(bool WidgetState, EButtonState Butto
 
   AQWaveform_RB->SetEnabled(WidgetState);
   AQSpectrum_RB->SetEnabled(WidgetState);
+  AQRate_RB->SetEnabled(WidgetState);
   AQPSDHistogram_RB->SetEnabled(WidgetState);
   
   DGTriggerType_CBL->GetComboBox()->SetEnabled(WidgetState);
@@ -2898,6 +2902,7 @@ void AAInterface::SaveSettings()
     // Scope display
     TheSettings->WaveformMode = AQWaveform_RB->IsDown();
     TheSettings->SpectrumMode = AQSpectrum_RB->IsDown();
+    TheSettings->RateMode = AQRate_RB->IsDown();
     TheSettings->PSDMode = AQPSDHistogram_RB->IsDown();
     
     // Trigger control settings
@@ -3062,6 +3067,7 @@ void AAInterface::SaveSettings()
       TheSettings->WaveformMode = AQWaveform_RB->IsDisabledAndSelected();
       TheSettings->SpectrumMode = AQSpectrum_RB->IsDisabledAndSelected();
       TheSettings->PSDMode = AQPSDHistogram_RB->IsDisabledAndSelected();
+      TheSettings->RateMode = AQRate_RB->IsDisabledAndSelected();
 
       TheSettings->TriggerCoincidenceEnable = DGTriggerCoincidenceEnable_CB->IsDisabledAndSelected();
       
@@ -3294,16 +3300,25 @@ void AAInterface::LoadSettingsFromFile()
       AQWaveform_RB->SetState(kButtonDown);
       AQSpectrum_RB->SetState(kButtonUp);
       AQPSDHistogram_RB->SetState(kButtonUp);
+      AQRate_RB->SetState(kButtonUp);
     }
     else if(TheSettings->SpectrumMode){
       AQWaveform_RB->SetState(kButtonUp);
       AQSpectrum_RB->SetState(kButtonDown);
       AQPSDHistogram_RB->SetState(kButtonUp);
+      AQRate_RB->SetState(kButtonUp);
     }
     else if(TheSettings->PSDMode){
       AQWaveform_RB->SetState(kButtonUp);
       AQSpectrum_RB->SetState(kButtonUp);
       AQPSDHistogram_RB->SetState(kButtonDown);
+      AQRate_RB->SetState(kButtonUp);
+    }
+    else if(TheSettings->RateMode){
+      AQWaveform_RB->SetState(kButtonUp);
+      AQSpectrum_RB->SetState(kButtonUp);
+      AQPSDHistogram_RB->SetState(kButtonUp);
+      AQRate_RB->SetState(kButtonDown);
     }
 
     // Trigger control

--- a/src/AAInterface.cc
+++ b/src/AAInterface.cc
@@ -2533,15 +2533,6 @@ void AAInterface::FillAcquisitionFrame()
   RatePlotPeriod_NEL->GetEntry()->Resize(50,20);
   RatePlotPeriod_NEL->GetEntry()->SetNumber(2);
 
-  RateDrawOptions_GF->AddFrame(RateTSResolution_NEL = new ADAQNumberEntryWithLabel(RateDrawOptions_GF, "Timestamp Resolution (ns)", -1),
-			      new TGLayoutHints(kLHintsNormal, 0,0,5,0));
-  RateTSResolution_NEL->GetEntry()->SetNumStyle(TGNumberFormat::kNESReal);
-  RateTSResolution_NEL->GetEntry()->SetNumAttr(TGNumberFormat::kNEAPositive);
-  RateTSResolution_NEL->GetEntry()->Resize(50,20);
-  RateTSResolution_NEL->GetEntry()->SetNumber(4);
-
-
-
   DrawSpectrumWithLine_RB->Connect("Clicked()", "AASubtabSlots", SubtabSlots, "HandleRadioButtons()");
   DrawSpectrumWithLine_RB->SetState(kButtonDown);
   
@@ -2733,7 +2724,6 @@ void AAInterface::SetAcquisitionWidgetState(bool WidgetState, EButtonState Butto
 
   RatePlotDisp_NEL->GetEntry()->SetState(WidgetState);
   RatePlotPeriod_NEL->GetEntry()->SetState(WidgetState);
-  RateTSResolution_NEL->GetEntry()->SetState(WidgetState);
 
   // The following widgets have special settings depending on
   // the acquisition state
@@ -3075,7 +3065,6 @@ void AAInterface::SaveSettings()
     TheSettings->RateChannel = RateChannel_CBL->GetComboBox()->GetSelected();
     TheSettings->RateIntegrationPeriod = RatePlotPeriod_NEL->GetEntry()->GetNumber();
     TheSettings->RateDisplayPeriod = RatePlotDisp_NEL->GetEntry()->GetNumber();
-    TheSettings->RateTSResolution = RateTSResolution_NEL->GetEntry()->GetNumber();
 
     TheSettings->SpectrumRefreshRate = SpectrumRefreshRate_NEL->GetEntry()->GetIntNumber();
 

--- a/src/AAInterface.cc
+++ b/src/AAInterface.cc
@@ -957,7 +957,7 @@ void AAInterface::FillAcquisitionFrame()
   }
 
   DGChEnable_CB_ID_Vec += 
-    (Int_t)DGCh0Enable_CB_ID,  (Int_t)DGCh1Enable_CB_ID,  (Int_t)DGCh2Enable_CB_ID, 
+    (Int_t)DGCh0Enable_CB_ID,  (Int_t)DGCh1Enable_CB_ID,  (Int_t)DGCh2Enable_CB_ID,
     (Int_t)DGCh3Enable_CB_ID,  (Int_t)DGCh4Enable_CB_ID,  (Int_t)DGCh5Enable_CB_ID, 
     (Int_t)DGCh6Enable_CB_ID,  (Int_t)DGCh7Enable_CB_ID,  (Int_t)DGCh8Enable_CB_ID,
     (Int_t)DGCh9Enable_CB_ID,  (Int_t)DGCh10Enable_CB_ID, (Int_t)DGCh11Enable_CB_ID,
@@ -2518,7 +2518,6 @@ void AAInterface::FillAcquisitionFrame()
   SpectrumRefreshRate_NEL->GetEntry()->SetNumAttr(TGNumberFormat::kNEAPositive);
   SpectrumRefreshRate_NEL->GetEntry()->Resize(50,20);
   SpectrumRefreshRate_NEL->GetEntry()->SetNumber(100);
-  
 
   TGButtonGroup *DisplayControl_BG = new TGButtonGroup(DisplayControl_GF, "");
   DisplayControl_BG->SetBorderDrawn(false);

--- a/src/AAInterface.cc
+++ b/src/AAInterface.cc
@@ -2531,7 +2531,7 @@ void AAInterface::FillAcquisitionFrame()
   RatePlotPeriod_NEL->GetEntry()->SetNumStyle(TGNumberFormat::kNESReal);
   RatePlotPeriod_NEL->GetEntry()->SetNumAttr(TGNumberFormat::kNEAPositive);
   RatePlotPeriod_NEL->GetEntry()->Resize(50,20);
-  RatePlotPeriod_NEL->GetEntry()->SetNumber(2);
+  RatePlotPeriod_NEL->GetEntry()->SetNumber(0.1);
 
   DrawSpectrumWithLine_RB->Connect("Clicked()", "AASubtabSlots", SubtabSlots, "HandleRadioButtons()");
   DrawSpectrumWithLine_RB->SetState(kButtonDown);

--- a/src/AAInterface.cc
+++ b/src/AAInterface.cc
@@ -2531,7 +2531,7 @@ void AAInterface::FillAcquisitionFrame()
   RatePlotPeriod_NEL->GetEntry()->SetNumStyle(TGNumberFormat::kNESReal);
   RatePlotPeriod_NEL->GetEntry()->SetNumAttr(TGNumberFormat::kNEAPositive);
   RatePlotPeriod_NEL->GetEntry()->Resize(50,20);
-  RatePlotPeriod_NEL->GetEntry()->SetNumber(1);
+  RatePlotPeriod_NEL->GetEntry()->SetNumber(2);
 
   RateDrawOptions_GF->AddFrame(RateTSResolution_NEL = new ADAQNumberEntryWithLabel(RateDrawOptions_GF, "Timestamp Resolution (ns)", -1),
 			      new TGLayoutHints(kLHintsNormal, 0,0,5,0));
@@ -3074,7 +3074,7 @@ void AAInterface::SaveSettings()
 
     TheSettings->RateChannel = RateChannel_CBL->GetComboBox()->GetSelected();
     TheSettings->RateIntegrationPeriod = RatePlotPeriod_NEL->GetEntry()->GetNumber();
-    TheSettings->RateDisplayPeriod = RatePlotPeriod_NEL->GetEntry()->GetNumber();
+    TheSettings->RateDisplayPeriod = RatePlotDisp_NEL->GetEntry()->GetNumber();
     TheSettings->RateTSResolution = RateTSResolution_NEL->GetEntry()->GetNumber();
 
     TheSettings->SpectrumRefreshRate = SpectrumRefreshRate_NEL->GetEntry()->GetIntNumber();

--- a/src/AAInterface.cc
+++ b/src/AAInterface.cc
@@ -2731,6 +2731,10 @@ void AAInterface::SetAcquisitionWidgetState(bool WidgetState, EButtonState Butto
   PSDTailMaxBin_NEL->GetEntry()->SetState(WidgetState);
   PSDThreshold_NEL->GetEntry()->SetState(WidgetState);
 
+  RatePlotDisp_NEL->GetEntry()->SetState(WidgetState);
+  RatePlotPeriod_NEL->GetEntry()->SetState(WidgetState);
+  RateTSResolution_NEL->GetEntry()->SetState(WidgetState);
+
   // The following widgets have special settings depending on
   // the acquisition state
   

--- a/src/AASubtabSlots.cc
+++ b/src/AASubtabSlots.cc
@@ -681,6 +681,7 @@ void AASubtabSlots::HandleRadioButtons()
 
   case AQWaveform_RB_ID:
   case AQSpectrum_RB_ID:
+  case AQRate_RB_ID:
   case AQPSDHistogram_RB_ID:
 
     // Reset the horizontal and vertical sliders to restore the


### PR DESCRIPTION
**This change to ADAQAcquisition will require the functionality added to ADAQ in my recent pull request for that fork (bhendersonWY/ADAQ)**

This fork implements a plot of the trigger rate as a function of time as additional display option in the Acquisition tab.  Options are included to set the time integration window for the rate calculation as well as the total amount of time displayed by the plot.

Tested with a DT5790M on two separate Ubuntu machines.  No issues with switching back and forth between the different plots and plotting options and the zoom slider bars work with the rate plot.