### PR TITLE
Adding DT5790 coincidence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ bin/*
 doc/build/*
 doc/ADAQAcquisition_UsersGuide.pdf
 include/boost/*
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,4 @@ bin/*
 # Ignore all documentation transients and PDF
 doc/build/*
 doc/ADAQAcquisition_UsersGuide.pdf
-
+include/boost/*


### PR DESCRIPTION
First pull request; merges changes since April, and sets Trigger Coincidence on at the right time for ADAQDigitizer to enable coincidence for the PSD firmware, specifically for the DT5790 digitizer. 

This will not work on other PSD digitzers yet, as there are slightly different registers to be written.