### PR TITLE
Added user setting of coincidence window and channels.

### DIFF
--- a/include/AAInterface.hh
+++ b/include/AAInterface.hh
@@ -283,6 +283,7 @@ private:
   ADAQComboBoxWithLabel *DGTriggerEdge_CBL;
   ADAQNumberEntryWithLabel *DGPSDTriggerHoldoff_NEL;
   TGCheckButton *DGTriggerCoincidenceEnable_CB;
+  ADAQNumberEntryWithLabel *DGTriggerCoincidenceWindow_NEL;
   ADAQComboBoxWithLabel *DGTriggerCoincidenceLevel_CBL;
   
   ADAQComboBoxWithLabel *DGAcquisitionControl_CBL;

--- a/include/AAInterface.hh
+++ b/include/AAInterface.hh
@@ -283,8 +283,6 @@ private:
   ADAQComboBoxWithLabel *DGTriggerEdge_CBL;
   ADAQNumberEntryWithLabel *DGPSDTriggerHoldoff_NEL;
   TGCheckButton *DGTriggerCoincidenceEnable_CB;
-  ADAQNumberEntryWithLabel *DGTriggerCoincidenceWindow_NEL;
-  ADAQComboBoxWithLabel *DGTriggerCoincidenceLevel_CBL;
   
   ADAQComboBoxWithLabel *DGAcquisitionControl_CBL;
   ADAQNumberEntryWithLabel *DGRecordLength_NEL;
@@ -385,6 +383,12 @@ private:
   ADAQNumberEntryWithLabel *RatePlotPeriod_NEL;
 
   TGRadioButton *DisplayContinuous_RB, *DisplayUpdateable_RB, *DisplayNonUpdateable_RB;
+
+  // Coincidence
+  ADAQNumberEntryWithLabel *DGTriggerCoincidenceWindow_NEL;
+  ADAQComboBoxWithLabel *DGTriggerCoincidenceLevel_CBL;
+  ADAQComboBoxWithLabel *DGTriggerCoincidenceChannel1_CBL;
+  ADAQComboBoxWithLabel *DGTriggerCoincidenceChannel2_CBL;
 
 
   // Define the AAInterface class to ROOT 

--- a/include/AASettings.hh
+++ b/include/AASettings.hh
@@ -163,6 +163,7 @@ public:
   string TriggerTypeName, TriggerEdgeName;
   Int_t PSDTriggerHoldoff;
   Bool_t TriggerCoincidenceEnable;
+  Int_t TriggerCoincidenceWindow;
   Int_t TriggerCoincidenceLevel;
 
   

--- a/include/AASettings.hh
+++ b/include/AASettings.hh
@@ -163,8 +163,6 @@ public:
   string TriggerTypeName, TriggerEdgeName;
   Int_t PSDTriggerHoldoff;
   Bool_t TriggerCoincidenceEnable;
-  Int_t TriggerCoincidenceWindow;
-  Int_t TriggerCoincidenceLevel;
 
   
   // Acquisition
@@ -256,6 +254,14 @@ public:
   int SpectrumRefreshRate;
   
   Bool_t DisplayContinuous, DisplayUpdateable, DisplayNonUpdateable;
+
+  //////////////////////
+  // Coincidence widgets
+
+  Int_t TriggerCoincidenceWindow;
+  Int_t TriggerCoincidenceLevel;
+  Int_t TriggerCoincidenceChannel1;
+  Int_t TriggerCoincidenceChannel2;
   
   ClassDef(AASettings, 1);
 };

--- a/include/AATypes.hh
+++ b/include/AATypes.hh
@@ -249,8 +249,6 @@ enum{
   DGTriggerEdge_CBL_ID,
   DGPSDTriggerHoldoff_NEL_ID,
   DGTriggerCoincidenceEnable_CB_ID,
-  DGTriggerCoincidenceWindow_NEL_ID,
-  DGTriggerCoincidenceLevel_CBL_ID,
 
   DGAcquisitionControl_CBL_ID,
   DGRecordLength_NEL_ID,
@@ -359,7 +357,13 @@ enum{
   DisplayNonUpdateable_RB_ID,
 
   RateChannel_CBL_ID,
-  RateDrawOptions_CBL_ID
+  RateDrawOptions_CBL_ID,
+
+  // Coincidence Subtab
+  DGTriggerCoincidenceWindow_NEL_ID,
+  DGTriggerCoincidenceLevel_CBL_ID,
+  DGTriggerCoincidenceChannel1_CBL_ID,
+  DGTriggerCoincidenceChannel2_CBL_ID
 };
 
 struct CalibrationDataStruct{

--- a/include/AATypes.hh
+++ b/include/AATypes.hh
@@ -249,6 +249,7 @@ enum{
   DGTriggerEdge_CBL_ID,
   DGPSDTriggerHoldoff_NEL_ID,
   DGTriggerCoincidenceEnable_CB_ID,
+  DGTriggerCoincidenceWindow_NEL_ID,
   DGTriggerCoincidenceLevel_CBL_ID,
 
   DGAcquisitionControl_CBL_ID,

--- a/src/AAInterface.cc
+++ b/src/AAInterface.cc
@@ -1660,6 +1660,10 @@ void AAInterface::FillAcquisitionFrame()
   TGCompositeFrame *GraphicsSubframe = new TGCompositeFrame(GraphicsSubtab, 0, 0, kHorizontalFrame);
   GraphicsSubtab->AddFrame(GraphicsSubframe);
 
+  TGCompositeFrame *CoincidenceSubtab = AQControlSubtabs->AddTab(" Coincidence ");
+  TGCompositeFrame *CoincidenceSubframe = new TGCompositeFrame(CoincidenceSubtab, 0, 0, kHorizontalFrame);
+  CoincidenceSubtab->AddFrame(CoincidenceSubframe);
+
   SubtabFrame->AddFrame(AQControlSubtabs, new TGLayoutHints(kLHintsTop, 0,0,0,0));
 
 
@@ -1728,7 +1732,7 @@ void AAInterface::FillAcquisitionFrame()
   }
   else if(FirmwareType == "PSD"){
     DGTriggerControls_GF->AddFrame(DGPSDTriggerHoldoff_NEL = new ADAQNumberEntryWithLabel(DGTriggerControls_GF, "Holdoff (samples)", DGPSDTriggerHoldoff_NEL_ID),
-				   new TGLayoutHints(kLHintsNormal,5,0,0,5));
+				   new TGLayoutHints(kLHintsNormal,5,15,10,5));
     DGPSDTriggerHoldoff_NEL->GetEntry()->SetNumStyle(TGNumberFormat::kNESInteger);
     DGPSDTriggerHoldoff_NEL->GetEntry()->SetNumAttr(TGNumberFormat::kNEAPositive);
     DGPSDTriggerHoldoff_NEL->GetEntry()->Resize(60,20);
@@ -1736,30 +1740,9 @@ void AAInterface::FillAcquisitionFrame()
   }
   
   DGTriggerControls_GF->AddFrame(DGTriggerCoincidenceEnable_CB = new TGCheckButton(DGTriggerControls_GF, "Coincidence triggering", DGTriggerCoincidenceEnable_CB_ID),
-				 new TGLayoutHints(kLHintsNormal,5,5,0,0));
+				 new TGLayoutHints(kLHintsNormal,5,15,0,0));
   DGTriggerCoincidenceEnable_CB->Connect("Clicked()", "AASubtabSlots", SubtabSlots, "HandleCheckButtons()");
   
-  DGTriggerControls_GF->AddFrame(DGTriggerCoincidenceWindow_NEL = new ADAQNumberEntryWithLabel(DGTriggerControls_GF, "Window (samples)",DGTriggerCoincidenceWindow_NEL_ID),
-          new TGLayoutHints(kLHintsNormal,5,5,0,0));
-  DGTriggerCoincidenceWindow_NEL->GetEntry()->SetNumStyle(TGNumberFormat::kNESInteger);
-  DGTriggerCoincidenceWindow_NEL->GetEntry()->SetNumAttr(TGNumberFormat::kNEAPositive);
-  DGTriggerCoincidenceWindow_NEL->GetEntry()->Resize(60,20);
-  DGTriggerCoincidenceWindow_NEL->GetEntry()->SetNumber(5);
-  DGTriggerCoincidenceWindow_NEL->GetEntry()->Connect("ValueSet(long)", "AASubtabSlots", SubtabSlots, "HandleNumberEntries()");
-
-  DGTriggerControls_GF->AddFrame(DGTriggerCoincidenceLevel_CBL = new ADAQComboBoxWithLabel(DGTriggerControls_GF, "Level", DGTriggerCoincidenceLevel_CBL_ID),
-				 new TGLayoutHints(kLHintsNormal,5,5,0,0));
-  DGTriggerCoincidenceLevel_CBL->GetComboBox()->AddEntry("2 channel",1);
-  DGTriggerCoincidenceLevel_CBL->GetComboBox()->AddEntry("3 channel",2);
-  DGTriggerCoincidenceLevel_CBL->GetComboBox()->AddEntry("4 channel",3);
-  DGTriggerCoincidenceLevel_CBL->GetComboBox()->AddEntry("5 channel",4);
-  DGTriggerCoincidenceLevel_CBL->GetComboBox()->AddEntry("6 channel",5);
-  DGTriggerCoincidenceLevel_CBL->GetComboBox()->AddEntry("7 channel",6);
-  DGTriggerCoincidenceLevel_CBL->GetComboBox()->AddEntry("8 channel",7);
-  DGTriggerCoincidenceLevel_CBL->GetComboBox()->Select(1);
-  DGTriggerCoincidenceLevel_CBL->GetComboBox()->SetEnabled(false);
-  
-
   ///////////////////////
   // Acquisition controls
 
@@ -2597,6 +2580,86 @@ void AAInterface::FillAcquisitionFrame()
 
   DrawSpectrumWithLine_RB->Connect("Clicked()", "AASubtabSlots", SubtabSlots, "HandleRadioButtons()");
   DrawSpectrumWithLine_RB->SetState(kButtonDown);
+
+  //////////////////////////////
+  //// Coincidence Controls ////
+  //////////////////////////////
+  TGGroupFrame *CoincidenceControl_GF = new TGGroupFrame(CoincidenceSubframe, "Control", kVerticalFrame);
+  CoincidenceControl_GF->SetTitlePos(TGGroupFrame::kCenter);
+  CoincidenceSubframe->AddFrame(CoincidenceControl_GF, new TGLayoutHints(kLHintsNormal,5,5,5,5));
+  
+  CoincidenceControl_GF->AddFrame(DGTriggerCoincidenceWindow_NEL = new ADAQNumberEntryWithLabel(CoincidenceControl_GF, "Window (samples)",DGTriggerCoincidenceWindow_NEL_ID),
+          new TGLayoutHints(kLHintsNormal,5,5,10,0));
+  DGTriggerCoincidenceWindow_NEL->GetEntry()->SetNumStyle(TGNumberFormat::kNESInteger);
+  DGTriggerCoincidenceWindow_NEL->GetEntry()->SetNumAttr(TGNumberFormat::kNEAPositive);
+  DGTriggerCoincidenceWindow_NEL->GetEntry()->Resize(60,20);
+  DGTriggerCoincidenceWindow_NEL->GetEntry()->SetNumber(5);
+  DGTriggerCoincidenceWindow_NEL->GetEntry()->Connect("ValueSet(long)", "AASubtabSlots", SubtabSlots, "HandleNumberEntries()");
+  DGTriggerCoincidenceWindow_NEL->GetEntry()->SetState(false);
+
+  CoincidenceControl_GF->AddFrame(DGTriggerCoincidenceLevel_CBL = new ADAQComboBoxWithLabel(CoincidenceControl_GF, "Level", DGTriggerCoincidenceLevel_CBL_ID),
+				 new TGLayoutHints(kLHintsNormal,5,5,10,0));
+  DGTriggerCoincidenceLevel_CBL->GetComboBox()->AddEntry("2 channel",1);
+  DGTriggerCoincidenceLevel_CBL->GetComboBox()->AddEntry("3 channel",2);
+  DGTriggerCoincidenceLevel_CBL->GetComboBox()->AddEntry("4 channel",3);
+  DGTriggerCoincidenceLevel_CBL->GetComboBox()->AddEntry("5 channel",4);
+  DGTriggerCoincidenceLevel_CBL->GetComboBox()->AddEntry("6 channel",5);
+  DGTriggerCoincidenceLevel_CBL->GetComboBox()->AddEntry("7 channel",6);
+  DGTriggerCoincidenceLevel_CBL->GetComboBox()->AddEntry("8 channel",7);
+  DGTriggerCoincidenceLevel_CBL->GetComboBox()->Select(1);
+  DGTriggerCoincidenceLevel_CBL->GetComboBox()->SetEnabled(false);
+
+  TGGroupFrame *CoincidenceChannels_GF = new TGGroupFrame(CoincidenceSubframe, "Channel Setup", kVerticalFrame);
+  CoincidenceChannels_GF->SetTitlePos(TGGroupFrame::kCenter);
+  CoincidenceSubframe->AddFrame(CoincidenceChannels_GF, new TGLayoutHints(kLHintsNormal,5,5,5,5));
+
+  ZBoardType DGType = TheVMEManager->GetDGManager()->GetBoardType();
+
+  CoincidenceChannels_GF->AddFrame(DGTriggerCoincidenceChannel1_CBL = new ADAQComboBoxWithLabel(CoincidenceChannels_GF, "Channel 1", DGTriggerCoincidenceChannel1_CBL_ID),
+				 new TGLayoutHints(kLHintsNormal,5,5,10,0));
+  DGTriggerCoincidenceChannel1_CBL->GetComboBox()->AddEntry("Channel 0",0);
+  DGTriggerCoincidenceChannel1_CBL->GetComboBox()->AddEntry("Channel 1",1);
+  if(DGType == zV1720 or DGType == zV1725){
+    DGTriggerCoincidenceChannel1_CBL->GetComboBox()->AddEntry("Channel 2",2);
+    DGTriggerCoincidenceChannel1_CBL->GetComboBox()->AddEntry("Channel 3",3);
+    DGTriggerCoincidenceChannel1_CBL->GetComboBox()->AddEntry("Channel 4",4);
+    DGTriggerCoincidenceChannel1_CBL->GetComboBox()->AddEntry("Channel 5",5);
+    DGTriggerCoincidenceChannel1_CBL->GetComboBox()->AddEntry("Channel 6",6);
+    DGTriggerCoincidenceChannel1_CBL->GetComboBox()->AddEntry("Channel 7",7);
+    DGTriggerCoincidenceChannel1_CBL->GetComboBox()->AddEntry("Channel 8",8);
+    DGTriggerCoincidenceChannel1_CBL->GetComboBox()->AddEntry("Channel 9",9);
+    DGTriggerCoincidenceChannel1_CBL->GetComboBox()->AddEntry("Channel 10",10);
+    DGTriggerCoincidenceChannel1_CBL->GetComboBox()->AddEntry("Channel 11",11);
+    DGTriggerCoincidenceChannel1_CBL->GetComboBox()->AddEntry("Channel 12",12);
+    DGTriggerCoincidenceChannel1_CBL->GetComboBox()->AddEntry("Channel 13",13);
+    DGTriggerCoincidenceChannel1_CBL->GetComboBox()->AddEntry("Channel 14",14);
+    DGTriggerCoincidenceChannel1_CBL->GetComboBox()->AddEntry("Channel 15",15);
+  }
+  DGTriggerCoincidenceChannel1_CBL->GetComboBox()->Select(0);
+  DGTriggerCoincidenceChannel1_CBL->GetComboBox()->SetEnabled(false);  
+
+  CoincidenceChannels_GF->AddFrame(DGTriggerCoincidenceChannel2_CBL = new ADAQComboBoxWithLabel(CoincidenceChannels_GF, "Channel 2", DGTriggerCoincidenceChannel2_CBL_ID),
+				 new TGLayoutHints(kLHintsNormal,5,5,10,0));
+  DGTriggerCoincidenceChannel2_CBL->GetComboBox()->AddEntry("Channel 0",0);
+  DGTriggerCoincidenceChannel2_CBL->GetComboBox()->AddEntry("Channel 1",1);
+  if(DGType == zV1720 or DGType == zV1725){
+    DGTriggerCoincidenceChannel2_CBL->GetComboBox()->AddEntry("Channel 2",2);
+    DGTriggerCoincidenceChannel2_CBL->GetComboBox()->AddEntry("Channel 3",3);
+    DGTriggerCoincidenceChannel2_CBL->GetComboBox()->AddEntry("Channel 4",4);
+    DGTriggerCoincidenceChannel2_CBL->GetComboBox()->AddEntry("Channel 5",5);
+    DGTriggerCoincidenceChannel2_CBL->GetComboBox()->AddEntry("Channel 6",6);
+    DGTriggerCoincidenceChannel2_CBL->GetComboBox()->AddEntry("Channel 7",7);
+    DGTriggerCoincidenceChannel2_CBL->GetComboBox()->AddEntry("Channel 8",8);
+    DGTriggerCoincidenceChannel2_CBL->GetComboBox()->AddEntry("Channel 9",9);
+    DGTriggerCoincidenceChannel2_CBL->GetComboBox()->AddEntry("Channel 10",10);
+    DGTriggerCoincidenceChannel2_CBL->GetComboBox()->AddEntry("Channel 11",11);
+    DGTriggerCoincidenceChannel2_CBL->GetComboBox()->AddEntry("Channel 12",12);
+    DGTriggerCoincidenceChannel2_CBL->GetComboBox()->AddEntry("Channel 13",13);
+    DGTriggerCoincidenceChannel2_CBL->GetComboBox()->AddEntry("Channel 14",14);
+    DGTriggerCoincidenceChannel2_CBL->GetComboBox()->AddEntry("Channel 15",15);
+  }
+  DGTriggerCoincidenceChannel2_CBL->GetComboBox()->Select(1);
+  DGTriggerCoincidenceChannel2_CBL->GetComboBox()->SetEnabled(false);  
   
   MapSubwindows();
   MapWindow();
@@ -2992,8 +3055,6 @@ void AAInterface::SaveSettings()
     }
     
     TheSettings->TriggerCoincidenceEnable = DGTriggerCoincidenceEnable_CB->IsDown();
-    TheSettings->TriggerCoincidenceWindow = DGTriggerCoincidenceWindow_NEL->GetEntry()->GetIntNumber();
-    TheSettings->TriggerCoincidenceLevel = DGTriggerCoincidenceLevel_CBL->GetComboBox()->GetSelected();
 
     // Acquisition
     TheSettings->AcquisitionControl = DGAcquisitionControl_CBL->GetComboBox()->GetSelected();
@@ -3111,6 +3172,12 @@ void AAInterface::SaveSettings()
     TheSettings->DisplayContinuous = DisplayContinuous_RB->IsDown();
     TheSettings->DisplayUpdateable = DisplayUpdateable_RB->IsDown();
     TheSettings->DisplayNonUpdateable = DisplayNonUpdateable_RB->IsDown();
+
+    // Coincidence Subtab
+    TheSettings->TriggerCoincidenceWindow = DGTriggerCoincidenceWindow_NEL->GetEntry()->GetIntNumber();
+    TheSettings->TriggerCoincidenceLevel = DGTriggerCoincidenceLevel_CBL->GetComboBox()->GetSelected();
+    TheSettings->TriggerCoincidenceChannel1 = DGTriggerCoincidenceChannel1_CBL->GetComboBox()->GetSelected();
+    TheSettings->TriggerCoincidenceChannel2 = DGTriggerCoincidenceChannel2_CBL->GetComboBox()->GetSelected();
   
 
     ///////////////////////////////

--- a/src/AAInterface.cc
+++ b/src/AAInterface.cc
@@ -60,7 +60,7 @@ using namespace boost::assign;
 AAInterface::AAInterface(Bool_t ALS, string SFN)
   : TGMainFrame(gClient->GetRoot()),
     InterfaceBuildComplete(false),
-    DisplayWidth(1150), DisplayHeight(833), 
+    DisplayWidth(1150), DisplayHeight(850), 
     ButtonForeColor(kWhite), ButtonBackColorOn(kGreen-5), ButtonBackColorOff(kRed-3),
     SettingsFileName("DefaultSettings.acq.root"),
     AutoSaveSettings(false), AutoLoadSettings(false),
@@ -1739,6 +1739,14 @@ void AAInterface::FillAcquisitionFrame()
 				 new TGLayoutHints(kLHintsNormal,5,5,0,0));
   DGTriggerCoincidenceEnable_CB->Connect("Clicked()", "AASubtabSlots", SubtabSlots, "HandleCheckButtons()");
   
+  DGTriggerControls_GF->AddFrame(DGTriggerCoincidenceWindow_NEL = new ADAQNumberEntryWithLabel(DGTriggerControls_GF, "Window (samples)",DGTriggerCoincidenceWindow_NEL_ID),
+          new TGLayoutHints(kLHintsNormal,5,5,0,0));
+  DGTriggerCoincidenceWindow_NEL->GetEntry()->SetNumStyle(TGNumberFormat::kNESInteger);
+  DGTriggerCoincidenceWindow_NEL->GetEntry()->SetNumAttr(TGNumberFormat::kNEAPositive);
+  DGTriggerCoincidenceWindow_NEL->GetEntry()->Resize(60,20);
+  DGTriggerCoincidenceWindow_NEL->GetEntry()->SetNumber(5);
+  DGTriggerCoincidenceWindow_NEL->GetEntry()->Connect("ValueSet(long)", "AASubtabSlots", SubtabSlots, "HandleNumberEntries()");
+
   DGTriggerControls_GF->AddFrame(DGTriggerCoincidenceLevel_CBL = new ADAQComboBoxWithLabel(DGTriggerControls_GF, "Level", DGTriggerCoincidenceLevel_CBL_ID),
 				 new TGLayoutHints(kLHintsNormal,5,5,0,0));
   DGTriggerCoincidenceLevel_CBL->GetComboBox()->AddEntry("2 channel",1);
@@ -2699,6 +2707,7 @@ void AAInterface::SetAcquisitionWidgetState(bool WidgetState, EButtonState Butto
   else if(FirmwareType == "PSD")
     DGPSDTriggerHoldoff_NEL->GetEntry()->SetState(WidgetState);
   DGTriggerCoincidenceEnable_CB->SetState(ButtonState);
+  DGTriggerCoincidenceWindow_NEL->GetEntry()->SetState(WidgetState);
   
   DGAcquisitionControl_CBL->GetComboBox()->SetEnabled(WidgetState);
   if(FirmwareType == "STD"){
@@ -2983,6 +2992,7 @@ void AAInterface::SaveSettings()
     }
     
     TheSettings->TriggerCoincidenceEnable = DGTriggerCoincidenceEnable_CB->IsDown();
+    TheSettings->TriggerCoincidenceWindow = DGTriggerCoincidenceWindow_NEL->GetEntry()->GetIntNumber();
     TheSettings->TriggerCoincidenceLevel = DGTriggerCoincidenceLevel_CBL->GetComboBox()->GetSelected();
 
     // Acquisition
@@ -3405,6 +3415,8 @@ void AAInterface::LoadSettingsFromFile()
       DGTriggerCoincidenceEnable_CB->SetState(kButtonUp);
 
     DGTriggerCoincidenceLevel_CBL->GetComboBox()->Select(TheSettings->TriggerCoincidenceLevel);
+
+    DGTriggerCoincidenceWindow_NEL->GetEntry()->SetIntNumber(TheSettings->TriggerCoincidenceWindow);
 
     // Acquisition
 

--- a/src/AASubtabSlots.cc
+++ b/src/AASubtabSlots.cc
@@ -48,10 +48,18 @@ void AASubtabSlots::HandleCheckButtons()
   switch(ActiveID){
 
   case DGTriggerCoincidenceEnable_CB_ID:
-    if(ActiveButton->IsDown())
+    if(ActiveButton->IsDown()){
       TI->DGTriggerCoincidenceLevel_CBL->GetComboBox()->SetEnabled(true);
-    else
+      TI->DGTriggerCoincidenceWindow_NEL->GetEntry()->SetState(true);
+      TI->DGTriggerCoincidenceChannel1_CBL->GetComboBox()->SetEnabled(true);
+      TI->DGTriggerCoincidenceChannel2_CBL->GetComboBox()->SetEnabled(true);
+    }
+    else{
       TI->DGTriggerCoincidenceLevel_CBL->GetComboBox()->SetEnabled(false);
+      TI->DGTriggerCoincidenceWindow_NEL->GetEntry()->SetState(false);
+      TI->DGTriggerCoincidenceChannel1_CBL->GetComboBox()->SetEnabled(false);
+      TI->DGTriggerCoincidenceChannel2_CBL->GetComboBox()->SetEnabled(false);
+    }
     break;
 
   case SpectrumCalibration_CB_ID:

--- a/src/AASubtabSlots.cc
+++ b/src/AASubtabSlots.cc
@@ -15,6 +15,7 @@
 #include <sstream>
 #include <fstream>
 #include <iomanip>
+#include <iostream>
 
 #include "ADAQDigitizer.hh"
 
@@ -194,6 +195,9 @@ void AASubtabSlots::HandleNumberEntries()
   AAVMEManager *TheVMEManager = AAVMEManager::GetInstance();
 
   switch(ActiveID){
+
+  case DGTriggerCoincidenceWindow_NEL_ID:
+    break;
     
   case SpectrumCalibrationEnergy_NEL_ID:
     break;

--- a/src/AAVMEManager.cc
+++ b/src/AAVMEManager.cc
@@ -245,15 +245,20 @@ bool AAVMEManager::ProgramDigitizers()
 	break;
       }
     }
-  if(TheSettings->TriggerCoincidenceEnable and
-     TheSettings->TriggerCoincidenceLevel < DGNumChEnabled and
-     TheSettings->TriggerCoincidenceChannel1 != TheSettings->TriggerCoincidenceChannel2)
-     {
-      std::cout<<"Enabling STD Coincidence"<<std::endl;
-    DGMgr->SetTriggerCoincidence(true, TheSettings->TriggerCoincidenceLevel,TheSettings->TriggerCoincidenceWindow,
-                                  TheSettings->TriggerCoincidenceChannel1,TheSettings->TriggerCoincidenceChannel2);
-     }
-  }
+    if(TheSettings->TriggerCoincidenceEnable){
+      if(TheSettings->TriggerCoincidenceLevel < DGNumChEnabled 
+      and TheSettings->TriggerCoincidenceChannel1 != TheSettings->TriggerCoincidenceChannel2)
+    {
+      std::cout<<"Enabling PSD Coincidence"<<std::endl;
+      DGMgr->SetTriggerCoincidence(true, TheSettings->TriggerCoincidenceLevel,TheSettings->TriggerCoincidenceWindow,
+                                    TheSettings->TriggerCoincidenceChannel1,TheSettings->TriggerCoincidenceChannel2);
+    }
+      else if(TheSettings -> TriggerCoincidenceLevel > DGNumChEnabled)
+        cout<<"Error! Not enough channels enabled for "<<(TheSettings->TriggerCoindenceLevel+1)<<"channel coincidence."<<endl;
+      
+      else if(TheSettings->TriggerCoincidenceChannel1 != TheSettings->TriggerCoincidenceChannel2)
+        cout<<"Error! Cannot preform coincidence between a channel and itself. \n Please select two distinct channels." <<endl;
+    }
   
 
 
@@ -355,13 +360,19 @@ bool AAVMEManager::ProgramDigitizers()
       // by other values, so coincidence must be set on *AFTER* other parameters 
       // have been set
 
-    if(TheSettings->TriggerCoincidenceEnable and 
-      TheSettings->TriggerCoincidenceLevel < DGNumChEnabled 
+    if(TheSettings->TriggerCoincidenceEnable){
+      if(TheSettings->TriggerCoincidenceLevel < DGNumChEnabled 
       and TheSettings->TriggerCoincidenceChannel1 != TheSettings->TriggerCoincidenceChannel2)
     {
       std::cout<<"Enabling PSD Coincidence"<<std::endl;
       DGMgr->SetTriggerCoincidence(true, TheSettings->TriggerCoincidenceLevel,TheSettings->TriggerCoincidenceWindow,
                                     TheSettings->TriggerCoincidenceChannel1,TheSettings->TriggerCoincidenceChannel2);
+    }
+      else if(TheSettings -> TriggerCoincidenceLevel > DGNumChEnabled)
+        cout<<"Error! Not enough channels enabled for "<<(TheSettings->TriggerCoindenceLevel+1)<<"channel coincidence."<<endl;
+      
+      else if(TheSettings->TriggerCoincidenceChannel1 != TheSettings->TriggerCoincidenceChannel2)
+        cout<<"Error! Cannot preform coincidence between a channel and itself. \n Please select two distinct channels." <<endl;
     }
 
     ///////////////////////////////////////////////////////

--- a/src/AAVMEManager.cc
+++ b/src/AAVMEManager.cc
@@ -248,7 +248,7 @@ bool AAVMEManager::ProgramDigitizers()
   if(TheSettings->TriggerCoincidenceEnable and
      TheSettings->TriggerCoincidenceLevel < DGNumChEnabled){
       std::cout<<"Enabling STD Coincidence"<<std::endl;
-    DGMgr->SetTriggerCoincidence(true, TheSettings->TriggerCoincidenceLevel);
+    DGMgr->SetTriggerCoincidence(true, TheSettings->TriggerCoincidenceLevel,TheSettings->TriggerCoincidenceWindow);
      }
   }
   
@@ -354,7 +354,7 @@ bool AAVMEManager::ProgramDigitizers()
 
     if(TheSettings->TriggerCoincidenceEnable and TheSettings->TriggerCoincidenceLevel < DGNumChEnabled){
       std::cout<<"Enabling PSD Coincidence"<<std::endl;
-      DGMgr->SetTriggerCoincidence(true, TheSettings->TriggerCoincidenceLevel);
+      DGMgr->SetTriggerCoincidence(true, TheSettings->TriggerCoincidenceLevel,TheSettings->TriggerCoincidenceWindow);
     }
 
     ///////////////////////////////////////////////////////

--- a/src/AAVMEManager.cc
+++ b/src/AAVMEManager.cc
@@ -246,9 +246,12 @@ bool AAVMEManager::ProgramDigitizers()
       }
     }
   if(TheSettings->TriggerCoincidenceEnable and
-     TheSettings->TriggerCoincidenceLevel < DGNumChEnabled){
+     TheSettings->TriggerCoincidenceLevel < DGNumChEnabled and
+     TheSettings->TriggerCoincidenceChannel1 != TheSettings->TriggerCoincidenceChannel2)
+     {
       std::cout<<"Enabling STD Coincidence"<<std::endl;
-    DGMgr->SetTriggerCoincidence(true, TheSettings->TriggerCoincidenceLevel,TheSettings->TriggerCoincidenceWindow);
+    DGMgr->SetTriggerCoincidence(true, TheSettings->TriggerCoincidenceLevel,TheSettings->TriggerCoincidenceWindow,
+                                  TheSettings->TriggerCoincidenceChannel1,TheSettings->TriggerCoincidenceChannel2);
      }
   }
   
@@ -352,9 +355,13 @@ bool AAVMEManager::ProgramDigitizers()
       // by other values, so coincidence must be set on *AFTER* other parameters 
       // have been set
 
-    if(TheSettings->TriggerCoincidenceEnable and TheSettings->TriggerCoincidenceLevel < DGNumChEnabled){
+    if(TheSettings->TriggerCoincidenceEnable and 
+      TheSettings->TriggerCoincidenceLevel < DGNumChEnabled 
+      and TheSettings->TriggerCoincidenceChannel1 != TheSettings->TriggerCoincidenceChannel2)
+    {
       std::cout<<"Enabling PSD Coincidence"<<std::endl;
-      DGMgr->SetTriggerCoincidence(true, TheSettings->TriggerCoincidenceLevel,TheSettings->TriggerCoincidenceWindow);
+      DGMgr->SetTriggerCoincidence(true, TheSettings->TriggerCoincidenceLevel,TheSettings->TriggerCoincidenceWindow,
+                                    TheSettings->TriggerCoincidenceChannel1,TheSettings->TriggerCoincidenceChannel2);
     }
 
     ///////////////////////////////////////////////////////


### PR DESCRIPTION
Added ability for user to set coincidence window and choose which channels are used for coincidence.  User can only set channels for 2 channel coincidence currently.  Added new "Coincidence" subtab to acquisition window to hold coincidence settings, however Coincidence Enable checkbutton remains in the Data Acquisition subtab for ease of use.